### PR TITLE
fix: tool-guard TDZ error + rename HORNET_DIR → HORNET_SRC_DIR

### DIFF
--- a/pi/extensions/tool-guard.ts
+++ b/pi/extensions/tool-guard.ts
@@ -372,7 +372,7 @@ export default function (pi: ExtensionAPI) {
       }
       // Block writes to read-only source repo and protected runtime files
       if (isProtectedPath(filePath)) {
-        const rule = filePath.startsWith(HORNET_SRC_DIR)
+        const rule = HORNET_SRC_DIR && filePath.startsWith(HORNET_SRC_DIR)
           ? "readonly-source"
           : "protected-runtime";
         auditLog({
@@ -381,7 +381,7 @@ export default function (pi: ExtensionAPI) {
           blocked: true,
           rule,
         });
-        const desc = filePath.startsWith(HORNET_SRC_DIR)
+        const desc = HORNET_SRC_DIR && filePath.startsWith(HORNET_SRC_DIR)
           ? `${filePath} is in the read-only source repo ~/hornet/. Edit source and run deploy.sh instead.`
           : `${filePath} is a protected security file. Only the admin can modify it via deploy.sh.`;
         console.error(`🛡️ TOOL-GUARD BLOCKED [${rule}]: ${filePath}`);
@@ -417,7 +417,7 @@ export default function (pi: ExtensionAPI) {
       }
       // Block edits to read-only source repo and protected runtime files
       if (isProtectedPath(filePath)) {
-        const rule = filePath.startsWith(HORNET_SRC_DIR)
+        const rule = HORNET_SRC_DIR && filePath.startsWith(HORNET_SRC_DIR)
           ? "readonly-source"
           : "protected-runtime";
         auditLog({
@@ -426,7 +426,7 @@ export default function (pi: ExtensionAPI) {
           blocked: true,
           rule,
         });
-        const desc = filePath.startsWith(HORNET_SRC_DIR)
+        const desc = HORNET_SRC_DIR && filePath.startsWith(HORNET_SRC_DIR)
           ? `${filePath} is in the read-only source repo ~/hornet/. Edit source and run deploy.sh instead.`
           : `${filePath} is a protected security file. Only the admin can modify it via deploy.sh.`;
         console.error(`🛡️ TOOL-GUARD BLOCKED [${rule}]: ${filePath}`);


### PR DESCRIPTION
Two fixes:
1. `HORNET_DIR` was declared on line 253 but used on line 174 — `const` isn't hoisted, causing 'Cannot access before initialization' at extension load time.
2. Renamed internal variable `HORNET_DIR` → `HORNET_SRC_DIR` to match the env var `HORNET_SOURCE_DIR` semantics.