### PR TITLE
ci: add Arch Linux integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,10 +21,9 @@ jobs:
           - distro: ubuntu
             image: ubuntu-24-04-x64
             setup_script: bin/ci/setup-ubuntu.sh
-          # To add Arch (or other distros), add entries here:
-          # - distro: arch
-          #   image: arch-linux-x64  # or a custom snapshot ID
-          #   setup_script: bin/ci/setup-arch.sh
+          - distro: arch
+            image: "217410218"
+            setup_script: bin/ci/setup-arch.sh
 
     name: ${{ matrix.distro }}
     timeout-minutes: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ bin/                        security & operations scripts
   ci/                       CI integration scripts
     droplet.sh              ephemeral DigitalOcean droplet lifecycle (create/destroy/ssh)
     setup-ubuntu.sh         Ubuntu droplet: prereqs + setup + tests
+    setup-arch.sh           Arch Linux droplet: prereqs + setup + tests
 hooks/
   pre-commit                blocks agent from modifying security files in git
 pi/

--- a/bin/ci/setup-arch.sh
+++ b/bin/ci/setup-arch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# CI setup script for Arch Linux droplets.
+# Runs as root on a fresh droplet. Installs prereqs, uploads source,
+# runs setup.sh, and executes the test suite.
+#
+# Expects: /tmp/hornet-src.tar.gz already uploaded via scp.
+
+set -euo pipefail
+
+echo "=== [Arch] Installing prerequisites ==="
+pacman -Syu --noconfirm --needed git curl tmux iptables docker sudo 2>&1 | tail -10
+
+echo "=== Preparing source ==="
+useradd -m -s /bin/bash hornet_admin
+mkdir -p /home/hornet_admin/hornet
+cd /home/hornet_admin/hornet
+tar xzf /tmp/hornet-src.tar.gz
+chown -R hornet_admin:hornet_admin /home/hornet_admin/
+sudo -u hornet_admin bash -c 'cd ~/hornet && git init -q && git config user.email "ci@test" && git config user.name "CI" && git add -A && git commit -q -m "init"'
+
+echo "=== Running setup.sh ==="
+cd /
+bash /home/hornet_admin/hornet/setup.sh hornet_admin
+
+echo "=== Installing test dependencies ==="
+export PATH="/home/hornet_agent/opt/node-v22.14.0-linux-x64/bin:$PATH"
+cd /home/hornet_admin/hornet
+npm install --ignore-scripts 2>&1 | tail -1
+cd slack-bridge && npm install 2>&1 | tail -1
+cd ..
+
+echo "=== Running tests ==="
+bash bin/test.sh
+
+echo ""
+echo "✅ All checks passed on Arch Linux"


### PR DESCRIPTION
Add Arch Linux to the integration test matrix.

- `bin/ci/setup-arch.sh`: Arch prereqs via pacman + setup.sh + test suite
- Uses official Arch cloud image uploaded as DO custom image (ID 217410218)
- Tested locally: all 5 test suites pass on fresh Arch droplet

This runs alongside the existing Ubuntu integration test — both distros in parallel.