### PR TITLE
Remove private flag from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "baudbot",
-  "private": true,
   "scripts": {
     "test": "bin/test.sh",
     "test:js": "bin/test.sh js",


### PR DESCRIPTION
Removes `"private": true` from package.json. This flag signals the package isn't meant to be shared, which doesn't make sense for an open source repo.

Closes TODO-6a40bb4b.