### PR TITLE
Fix orphaned CI droplets on cancelled runs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,4 +79,5 @@ jobs:
         run: |
           bash bin/ci/droplet.sh destroy \
             "${{ steps.droplet.outputs.DROPLET_ID }}" \
-            "${{ steps.droplet.outputs.SSH_KEY_ID }}"
+            "${{ steps.droplet.outputs.SSH_KEY_ID }}" \
+            "ci-${{ matrix.distro }}-${{ github.run_id }}"


### PR DESCRIPTION
## Problem

CI droplets leak when a GitHub Actions run is cancelled mid-create. The droplet gets created on DigitalOcean but the ID never makes it to `GITHUB_OUTPUT`, so the cleanup step has nothing to destroy.

## Fix

- Tag all CI droplets with `baudbot-ci` on creation
- Pass the deterministic droplet name (`ci-{distro}-{run_id}`) to the cleanup step as a third arg
- `cmd_destroy` falls back to looking up the droplet by name when no ID is available
- Add `droplet.sh list` command for debugging orphans

## Still needed

The 10 existing orphan droplets need to be manually destroyed. Run:
```bash
export DO_API_TOKEN=...
# These predate the baudbot-ci tag, so list all:
curl -s -H "Authorization: Bearer $DO_API_TOKEN" \
  "https://api.digitalocean.com/v2/droplets?per_page=100" \
  | python3 -c "import json,sys; [print(f'{d[\"id\"]}  {d[\"name\"]}') for d in json.load(sys.stdin)['droplets']]"
# Then destroy each:
for id in <ids>; do
  curl -s -X DELETE -H "Authorization: Bearer $DO_API_TOKEN" \
    "https://api.digitalocean.com/v2/droplets/$id"
done
```