### PR TITLE
config: accept both ghp_ and github_pat_ tokens in schema

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -33,8 +33,8 @@ OPENCODE_ZEN_API_KEY=
 
 # ── GitHub ───────────────────────────────────────────────────────────────────
 
-# GitHub Personal Access Token (fine-grained, scoped to agent repos)
-# @required @type=string(startsWith=ghp_)
+# GitHub Personal Access Token (classic ghp_ or fine-grained github_pat_)
+# @required @type=string
 # @docs(https://github.com/settings/tokens)
 GITHUB_TOKEN=
 


### PR DESCRIPTION
The `.env.schema` had `startsWith=ghp_` on `GITHUB_TOKEN`, which rejects fine-grained PATs (`github_pat_` prefix). This caused varlock validation to fail and the agent to crash-loop on startup.

Varlock doesn't support multiple `startsWith` values, so the prefix constraint is removed from the schema. The soft validation in `config.sh` still warns on unexpected prefixes.