### PR TITLE
ops: smoother update and deploy workflows

### DIFF
--- a/bin/baudbot
+++ b/bin/baudbot
@@ -123,7 +123,7 @@ case "${1:-}" in
 
   status)
     shift
-    if has_systemd && systemctl is-enabled baudbot &>/dev/null 2>&1; then
+    if has_systemd && systemctl is-enabled baudbot &>/dev/null; then
       exec systemctl status baudbot "$@"
     else
       # Fallback: check if baudbot_agent has pi running
@@ -138,7 +138,7 @@ case "${1:-}" in
 
   logs)
     shift
-    if has_systemd && systemctl is-enabled baudbot &>/dev/null 2>&1; then
+    if has_systemd && systemctl is-enabled baudbot &>/dev/null; then
       exec journalctl -u baudbot -f "$@"
     else
       echo "No systemd unit. Check tmux sessions:"
@@ -263,11 +263,12 @@ case "${1:-}" in
     "$BAUDBOT_ROOT/bin/deploy.sh" "$@"
     echo ""
     # Restart if currently running
-    if has_systemd && systemctl is-active baudbot &>/dev/null 2>&1; then
+    if has_systemd && systemctl is-active baudbot &>/dev/null; then
       echo "=== Restarting ==="
       systemctl restart baudbot
-      sleep 2
-      if systemctl is-active baudbot &>/dev/null 2>&1; then
+      # Wait for ExecStartPre hooks + process init
+      sleep 3
+      if systemctl is-active baudbot &>/dev/null; then
         echo "✅ Updated and running"
       else
         echo "⚠️  Deployed but agent didn't restart — check: baudbot logs"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -273,7 +273,7 @@ echo "Deploying config..."
 # Priority: BAUDBOT_CONFIG_USER env > SUDO_USER > repo owner > whoami
 if [ -n "${BAUDBOT_CONFIG_USER:-}" ]; then
   DEPLOY_USER="$BAUDBOT_CONFIG_USER"
-elif [ -n "${SUDO_USER:-}" ] && [ "${SUDO_USER}" != "root" ]; then
+elif [ -n "${SUDO_USER:-}" ] && [ "${SUDO_USER:-}" != "root" ]; then
   DEPLOY_USER="$SUDO_USER"
 else
   # Detect from repo ownership (the admin owns the source)


### PR DESCRIPTION
## Problem

Updating baudbot required three separate commands:
```bash
cd ~/hornet && git pull origin main
sudo BAUDBOT_CONFIG_USER=bentlegen ~/hornet/bin/deploy.sh
sudo baudbot start
```

## Fix

### `baudbot update` does everything
```bash
sudo baudbot update
```
Pulls latest, deploys, and restarts if running. One command.

### `baudbot deploy` auto-detects admin user
No more `BAUDBOT_CONFIG_USER=bentlegen`. Deploy now detects the admin from the repo's file ownership (`stat -c '%U'`) when `SUDO_USER` isn't available. So `sudo baudbot deploy` just works.