### PR TITLE
docs: replace org-specific references with generic examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ The CI scripts (`bin/ci/setup-ubuntu.sh`, `bin/ci/setup-arch.sh`) run `install.s
 ## Git Workflow
 
 - **Never commit directly to `main`.** All changes go on feature branches with PRs.
-- One branch per todo/task. Branch names: `<gh-username>/<description>` (e.g. `benvinegar/add-uninstall-script`).
+- One branch per todo/task. Branch names: `<gh-username>/<description>` (e.g. `youruser/add-uninstall-script`).
 - Use `gh pr create` to open PRs (not the GitHub API with tokens).
 - Concise, action-oriented commit messages: `security: add rate limiting to bridge API`
 - Prefix with area: `security:`, `bridge:`, `deploy:`, `docs:`, `arch:`, `tests:`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ npm run lint && npm run typecheck
 ## Branches and PRs
 
 - Don't commit directly to `main`. Open a PR from a feature branch.
-- Branch names: `<your-gh-username>/<description>` (e.g. `benvinegar/fix-firewall-rules`)
+- Branch names: `<your-gh-username>/<description>` (e.g. `youruser/fix-firewall-rules`)
 - Commit messages: prefix with area. Examples: `security: add rate limiting`, `bridge: fix reconnect`, `docs: update README`
 - One branch per change. Keep PRs focused.
 

--- a/pi/extensions/memory.test.mjs
+++ b/pi/extensions/memory.test.mjs
@@ -136,12 +136,12 @@ describe("memory: seed file content", () => {
 });
 
 describe("memory: repos.md has known repo sections", () => {
-  it("contains modem section", () => {
+  it("contains myapp section", () => {
     const content = fs.readFileSync(
       path.join(MEMORY_SEED_DIR, "repos.md"),
       "utf-8"
     );
-    assert.ok(content.includes("## modem"), "should have modem section");
+    assert.ok(content.includes("## myapp"), "should have myapp section");
   });
 
   it("contains website section", () => {
@@ -227,7 +227,7 @@ describe("memory: deploy seeding logic", () => {
     fs.mkdirSync(destDir, { recursive: true });
 
     // Only repos.md exists
-    const customRepos = "# Repos\n\n## modem\n- Uses Next.js 15\n";
+    const customRepos = "# Repos\n\n## myapp\n- Uses Next.js 15\n";
     fs.writeFileSync(path.join(destDir, "repos.md"), customRepos);
 
     for (const file of EXPECTED_SEED_FILES) {

--- a/pi/skills/control-agent/SKILL.md
+++ b/pi/skills/control-agent/SKILL.md
@@ -117,7 +117,7 @@ Dev agents are **ephemeral and task-scoped**. Each agent:
 - Is spun up for a specific task, then cleaned up when done
 - Starts in the root of a **git worktree** for the repo it's working on
 - Reads project context (`CODEX.md`) from its working directory on startup
-- Is named `dev-agent-<repo>-<todo-short>` (e.g. `dev-agent-modem-a8b7b331`)
+- Is named `dev-agent-<repo>-<todo-short>` (e.g. `dev-agent-myapp-a8b7b331`)
 
 ### Concurrency Limits
 
@@ -129,9 +129,9 @@ Dev agents are **ephemeral and task-scoped**. Each agent:
 
 | Repo | Path | GitHub |
 |------|------|--------|
-| modem | `~/workspace/modem` | modem-dev/modem |
-| website | `~/workspace/website` | modem-dev/website |
-| baudbot | `~/workspace/baudbot` | modem-dev/baudbot |
+| myapp | `~/workspace/myapp` | your-org/myapp |
+| website | `~/workspace/website` | your-org/website |
+| baudbot | `~/workspace/baudbot` | your-org/baudbot |
 
 ## Task Lifecycle
 
@@ -152,10 +152,10 @@ Reply in the original channel ("On it 👍") so the user knows you received it.
 ### 3. Determine which repo(s) are needed
 
 Analyze the request to decide which repo(s) the task involves:
-- Code changes to the product → `modem`
+- Code changes to the product → `myapp`
 - Website/blog changes → `website`
 - Agent infra changes → `baudbot`
-- Some tasks need multiple repos (e.g. "review modem commits, write a blog post on website")
+- Some tasks need multiple repos (e.g. "review myapp commits, write a blog post on website")
 
 ### 4. Spawn dev agent(s)
 
@@ -219,7 +219,7 @@ Full procedure for spinning up a task-scoped dev agent:
 
 ```bash
 # Variables
-REPO=modem                          # repo name
+REPO=myapp                          # repo name
 REPO_PATH=~/workspace/$REPO         # repo checkout path
 TODO_SHORT=a8b7b331                 # short todo ID (hex part)
 BRANCH=fix/some-descriptive-name    # descriptive branch name
@@ -254,8 +254,8 @@ tmux new-session -d -s $SESSION_NAME \
 After a dev agent reports completion:
 
 ```bash
-SESSION_NAME=dev-agent-modem-a8b7b331
-REPO=modem
+SESSION_NAME=dev-agent-myapp-a8b7b331
+REPO=myapp
 BRANCH=fix/some-descriptive-name
 
 # 1. Kill the tmux session (agent should have already exited, but ensure it)
@@ -361,7 +361,7 @@ Extract the **Channel** and **Thread** values from the metadata. Use the Thread 
 
 6. **Error handling** — if something fails, tell the user in the thread. Don't silently fail.
 
-7. **Vercel preview links** — when a PR is opened on a repo with Vercel deployments (e.g. `website`, `modem`), watch for the Vercel preview deployment to complete and share the preview URL in the Slack thread so the user can test quickly. Dev agents should include preview URLs in their completion reports.
+7. **Vercel preview links** — when a PR is opened on a repo with Vercel deployments (e.g. `website`, `myapp`), watch for the Vercel preview deployment to complete and share the preview URL in the Slack thread so the user can test quickly. Dev agents should include preview URLs in their completion reports.
 
 ## Startup
 

--- a/pi/skills/control-agent/memory/incidents.md
+++ b/pi/skills/control-agent/memory/incidents.md
@@ -6,8 +6,8 @@ Use this to recognize recurring patterns and avoid re-investigating known issues
 **DO NOT store secrets, API keys, or tokens in this file.**
 
 <!-- Example:
-## 2026-02-15 — Sentry alert: "TypeError: Cannot read properties of undefined" in modem ingest
-- **Root cause**: Missing null check in webhook handler when Stripe sends empty metadata
-- **Fix**: PR #142 — added defensive check + test
-- **Watch for**: Similar null access errors in other webhook handlers
+## YYYY-MM-DD — Sentry alert: "TypeError: Cannot read properties of undefined" in myapp ingest
+- **Root cause**: Missing null check in webhook handler when receiving empty metadata
+- **Fix**: PR #NNN — added defensive check + test
+- **Watch for**: Similar null access errors in other handlers
 -->

--- a/pi/skills/control-agent/memory/repos.md
+++ b/pi/skills/control-agent/memory/repos.md
@@ -4,7 +4,7 @@ Per-repo knowledge: build quirks, CI gotchas, architecture notes, common failure
 
 **DO NOT store secrets, API keys, or tokens in this file.**
 
-## modem
+## myapp
 
 <!-- Example:
 - Uses Next.js 15, needs Node 22+

--- a/pi/skills/control-agent/memory/users.md
+++ b/pi/skills/control-agent/memory/users.md
@@ -5,9 +5,9 @@ Communication preferences, timezone, priorities, and working patterns for each u
 **DO NOT store secrets, API keys, or tokens in this file.**
 
 <!-- Example:
-## Ben
-- Prefers concise Slack replies, no emoji overload
-- Timezone: EST (UTC-5)
-- Usually active 9am–6pm EST weekdays
-- Priorities: ship fast, iterate, keep PRs small
+## <username>
+- Communication style preferences
+- Timezone: <timezone>
+- Working hours
+- Priorities and preferences
 -->

--- a/pi/skills/dev-agent/SKILL.md
+++ b/pi/skills/dev-agent/SKILL.md
@@ -25,7 +25,7 @@ You are an **ephemeral coding worker agent** managed by Baudbot (the control age
 
 ## Session Identity
 
-Your session name follows the pattern `dev-agent-<repo>-<todo-short>`, e.g. `dev-agent-modem-a8b7b331`. This is set automatically by the `auto-name.ts` extension via the `PI_SESSION_NAME` env var. Do NOT try to run `/name`.
+Your session name follows the pattern `dev-agent-<repo>-<todo-short>`, e.g. `dev-agent-myapp-a8b7b331`. This is set automatically by the `auto-name.ts` extension via the `PI_SESSION_NAME` env var. Do NOT try to run `/name`.
 
 The repo name and todo ID are encoded in your session name. Baudbot uses this to track you.
 
@@ -33,7 +33,7 @@ The repo name and todo ID are encoded in your session name. Baudbot uses this to
 
 ```
 ~/workspace/
-├── modem/           ← product app repo (main branch, DO NOT commit here)
+├── myapp/           ← product app repo (main branch, DO NOT commit here)
 ├── website/         ← marketing site repo (main branch, DO NOT commit here)
 ├── baudbot/         ← agent infra repo
 └── worktrees/       ← all worktrees live here

--- a/setup.sh
+++ b/setup.sh
@@ -116,7 +116,7 @@ if [ -d "$REPO_DIR/.git" ]; then
 fi
 
 # Agent workspace repos — set as agent
-for repo in "$BAUDBOT_HOME/workspace/modem" "$BAUDBOT_HOME/workspace/website"; do
+for repo in "$BAUDBOT_HOME"/workspace/*/; do
   if [ -d "$repo/.git" ]; then
     sudo -u baudbot_agent git -C "$repo" config core.sharedRepository group
     echo "  ✓ $repo"


### PR DESCRIPTION
Replaces modem-dev and bentlegen-specific content with generic placeholders so the repo works as a template for any org.

**Changed:**
- Skill files: `modem` → `myapp`, `modem-dev/modem` → `your-org/myapp` (repos table, routing examples, spawn scripts, cleanup scripts)
- Memory seeds: modem repo section → myapp, Ben user example → generic placeholder, incident example → generic
- Memory tests: modem assertions → myapp (3 test changes)
- `setup.sh`: hardcoded `workspace/modem` and `workspace/website` paths → wildcard `workspace/*/`
- Branch name examples: `benvinegar/` → `youruser/`

**Kept (real functional references):**
- Canonical repo URLs (`modem-dev/baudbot`) in README, CONTRIBUTING, install.sh
- CI badge URLs
- `security@modem.dev` contact in SECURITY.md

All 321 tests pass.