### PR TITLE
bridge: auto-start from start.sh, survive agent restarts

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -37,13 +37,17 @@ umask 077
 SOCKET_DIR="$HOME/.pi/session-control"
 if [ -d "$SOCKET_DIR" ]; then
   echo "Cleaning stale session sockets..."
-  for sock in "$SOCKET_DIR"/*.sock; do
-    [ -e "$sock" ] || continue
-    # If no process has the socket open, it's stale
-    if ! fuser "$sock" &>/dev/null 2>&1; then
-      rm -f "$sock"
-    fi
-  done
+  if command -v fuser &>/dev/null; then
+    for sock in "$SOCKET_DIR"/*.sock; do
+      [ -e "$sock" ] || continue
+      # If no process has the socket open, it's stale
+      if ! fuser "$sock" &>/dev/null 2>&1; then
+        rm -f "$sock"
+      fi
+    done
+  else
+    echo "  fuser not found, skipping socket cleanup (install psmisc)"
+  fi
   # Clean broken alias symlinks
   for alias in "$SOCKET_DIR"/*.alias; do
     [ -L "$alias" ] || continue


### PR DESCRIPTION
## Problem

After a hard stop (`systemctl restart baudbot`), the agent comes back but the Slack bridge doesn't. The bridge was started by the LLM following a skill checklist — if the LLM didn't get to it, or the heartbeat hadn't fired yet (10 min interval), the bridge stayed dead. Users messaging the bot got no response.

The error:
```
Socket error: connect ENOENT /home/baudbot_agent/.pi/session-control/<old-uuid>.sock
```

## Fix

### `start.sh` — bridge is now infrastructure, not an LLM task

1. **Stale socket cleanup** — removes dead `.sock` files (checks with `fuser`) and broken `.alias` symlinks before launch
2. **Bridge auto-start** — launches the bridge in a tmux restart loop *before* pi starts. If it crashes, it restarts in 5s.

### `slack-bridge/bridge.mjs` — resilient to pi not being ready

1. **Lazy socket resolution** — doesn't crash on startup if no pi socket exists
2. **Per-message refresh** — `refreshSocket()` before every send, picks up new UUIDs after pi restarts
3. **Graceful degradation** — replies "agent is starting up" to users instead of crashing; drops Sentry alerts with a log line

## Before → After

**Before:** `systemctl start` → pi starts → LLM reads skill → LLM runs cleanup script → bridge starts (hope nothing goes wrong)

**After:** `systemctl start` → stale sockets cleaned → bridge starts (restart loop) → pi starts → bridge auto-discovers socket on first message

## Testing

Install + 8/8 test suites on both Arch and Ubuntu droplets.