### PR TITLE
dx: add lint/format to pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -82,6 +82,6 @@ if [ -n "$JS_FILES" ] && command -v npx &>/dev/null; then
   if npx biome --version &>/dev/null 2>&1; then
     # shellcheck disable=SC2086
     echo "$JS_FILES" | xargs npx biome check --write --no-errors-on-unmatched 2>/dev/null || true
-    echo "$JS_FILES" | xargs git add 2>/dev/null || true
+    echo "$JS_FILES" | xargs git diff --name-only 2>/dev/null | xargs git add 2>/dev/null || true
   fi
 fi


### PR DESCRIPTION
Adds auto lint/format on staged JS/TS files to the pre-commit hook.

## What changed
- Pre-commit hook now runs `biome check --write` on staged `.ts`/`.js`/`.mjs` files
- Fixed files are re-staged automatically
- Gracefully skips if biome isn't available (e.g., agent runtime without devDependencies)
- Runs **after** the existing protected-file blocking logic — security check happens first

## Why
Ensures consistent code style without developers remembering to run the formatter. Matches OpenClaw's pre-commit pattern.