### PR TITLE
ops: add runtime health checks to doctor.sh

### DIFF
--- a/bin/doctor.sh
+++ b/bin/doctor.sh
@@ -267,11 +267,13 @@ if [ -d "$SOCKET_DIR" ]; then
         STALE_SOCKS=$((STALE_SOCKS + 1))
       fi
     done
-  fi
-  if [ "$STALE_SOCKS" -gt 0 ]; then
-    warn "$STALE_SOCKS stale session socket(s) in $SOCKET_DIR"
+    if [ "$STALE_SOCKS" -gt 0 ]; then
+      warn "$STALE_SOCKS stale session socket(s) in $SOCKET_DIR"
+    else
+      pass "no stale session sockets"
+    fi
   else
-    pass "no stale session sockets"
+    warn "fuser not installed; skipping stale socket check"
   fi
 fi
 


### PR DESCRIPTION
Adds runtime health checks to `bin/doctor.sh`, aligned with what the heartbeat monitors at runtime.

### New checks
| Check | Pass | Warn | Fail |
|-------|------|------|------|
| Slack bridge | Responding on :7890 | Not responding | — |
| Disk usage | <80% | ≥80% | ≥90% |
| Stale sockets | None | Has stale .sock files | — |
| Worktrees | ≤5 | >5 (suggest cleanup) | — |
| Session logs | <500MB | ≥500MB (suggest pruning) | — |

These checks run after the existing dependency/security/agent checks, so `doctor.sh` now covers both setup correctness and runtime health.