### PR TITLE
docs: refocus README on team outcomes and move deep details to docs/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ Add new test files to `bin/test.sh` — don't scatter test invocations across CI
 - Extensions are deployed from `pi/extensions/` → agent's `~/.pi/agent/extensions/`.
 - Skills are deployed from `pi/skills/` → agent's `~/.pi/agent/skills/`.
 - Agent commits operational learnings to its own skills dir (not back to source).
-- **When changing behavior, update all docs.** Check and update: `README.md`, `CONFIGURATION.md`, skill files (`pi/skills/*/SKILL.md`), and `AGENTS.md`. Inline code examples in docs must match the actual implementation.
+- **When changing behavior, update all docs.** Check and update: `README.md`, relevant pages in `docs/`, `CONFIGURATION.md`, skill files (`pi/skills/*/SKILL.md`), and `AGENTS.md`. Inline code examples in docs must match the actual implementation.
 - **No distro-specific commands.** Scripts must work on both Arch and Ubuntu (and any standard Linux). Use `grep -E` (not `grep -P`), POSIX-compatible tools, and avoid package manager calls (`pacman`, `apt`, etc.). If a package is needed, document it as a prerequisite rather than auto-installing it.
 
 ## Testing on Droplets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,17 @@ git clone https://github.com/modem-dev/baudbot.git ~/baudbot
 npm install
 ```
 
+## Documentation map
+
+- Product/team workflow overview: [README.md](README.md)
+- Deep architecture and operations docs: [`docs/`](docs)
+- Security model: [SECURITY.md](SECURITY.md)
+- Configuration reference: [CONFIGURATION.md](CONFIGURATION.md)
+
 ## Running Tests
 
 ```bash
-# All tests (8 suites)
+# All tests (10 suites)
 bin/test.sh
 
 # JS/TS only

--- a/README.md
+++ b/README.md
@@ -5,23 +5,38 @@
 [![CI](https://github.com/modem-dev/baudbot/actions/workflows/ci.yml/badge.svg)](https://github.com/modem-dev/baudbot/actions/workflows/ci.yml)
 [![Integration](https://github.com/modem-dev/baudbot/actions/workflows/integration.yml/badge.svg)](https://github.com/modem-dev/baudbot/actions/workflows/integration.yml)
 
-**Like Openclaw, but for paranoid developer teams.**
+**Always-on, multiplayer coding agent infrastructure for engineering teams.**
 
-Baudbot runs AI agents as isolated Linux processes with defense-in-depth security. Agents code, test, deploy, monitor, and triage. They work on real repos with real tools. The infrastructure assumes agents *will* be prompt-injected and layers OS-level isolation so damage is contained even when the LLM is compromised.
+Baudbot runs a persistent AI control agent on Linux, connected to Slack, with worker agents that take tasks from request to PR. It works on real repositories with real tools (git, test runners, Docker wrapper, cloud browser automation), keeps persistent memory, and reports progress back in-thread.
 
-Built for Linux. Uses iptables, `/proc` hidepid, and Unix user isolation. Every PR is integration-tested on fresh Ubuntu 24.04 and Arch Linux droplets.
+Built for teams that want autonomous execution speed **without giving up operational control**.
 
-## Why
+## What Baudbot does
 
-Every agent framework gives the model shell access and hopes for the best. Baudbot enforces:
+- **Shared Slack interface for the whole team.** Anyone in allowed channels can hand work to the same agent system.
+- **Always-on response and fast handoffs.** The control agent stays live, triages work instantly, and spins up task-scoped coding agents.
+- **End-to-end coding loop.** Branch, code, run tests, open PR, watch CI, push fixes, report status.
+- **Linux-native execution.** Agents can run the same project commands your engineers run (including guarded container workflows).
+- **Persistent team memory.** The system learns repo quirks, recurring fixes, and collaboration preferences across restarts.
+- **Self-improving operations.** Agents can update non-security skills/extensions and propose upstream improvements via PRs.
 
-- **OS-level isolation.** Dedicated Unix user, no sudo, can't see other processes.
-- **Network control.** iptables per-UID port allowlist. Standard ports only (80/443/22/53). No listeners, no reverse shells on non-standard ports.
-- **Source/runtime separation.** Agent can't read or modify its own infrastructure.
-- **Dual-layer command blocking.** Dangerous patterns caught at two independent layers.
-- **Self-healing.** Permissions hardened on every boot, secrets redacted from logs.
+## Team agent, not a personal copilot
 
-No sandbox friction. Agents make real branches, run real tests, push real PRs. But they can't escalate privileges or open reverse shells.
+Baudbot is designed as shared engineering infrastructure, not a single-user desktop assistant:
+
+- multiplayer by default (Slack threads, shared todos, multiple sessions)
+- persistent service, not one-shot chat
+- autonomous task execution with humans in review loops
+- admin-managed runtime with deployment + rollback controls
+
+## How work flows (example)
+
+1. A developer asks in Slack: "Fix flaky auth tests in `myapp`."
+2. Baudbot acknowledges immediately in the same thread.
+3. Control agent creates a todo and spawns a `dev-agent` in a fresh git worktree.
+4. Dev agent fixes code, runs tests, opens a PR, and monitors CI.
+5. If CI fails, the dev agent iterates and pushes fixes automatically.
+6. Baudbot posts the PR link, CI status, and preview URL back to the original Slack thread.
 
 ## Requirements
 
@@ -30,7 +45,7 @@ No sandbox friction. Agents make real branches, run real tests, push real PRs. B
 | **OS** | Ubuntu 24.04 or Arch Linux | Any systemd-based Linux |
 | **RAM** | 4 GB (3 agents) | 8 GB (6 agents + builds/tests) |
 | **CPU** | 2 vCPU | 4 vCPU |
-| **Disk** | 20 GB | 40 GB+ (repos, node_modules, Docker images) |
+| **Disk** | 20 GB | 40 GB+ (repos, dependencies, Docker images) |
 
 ## Quick Start
 
@@ -39,176 +54,71 @@ git clone https://github.com/modem-dev/baudbot.git ~/baudbot
 sudo ~/baudbot/install.sh
 ```
 
-The installer detects your distro, installs dependencies, creates the agent user, sets up the firewall, and walks you through API keys. Takes ~2 minutes.
+Installer handles setup, dependencies, agent user creation, firewall setup, and initial configuration prompts.
 
-<details>
-<summary>Manual setup (without installer)</summary>
+After install:
 
 ```bash
-# Creates user, firewall, /opt release layout, permissions (run as root)
-sudo bash ~/baudbot/setup.sh <admin_username>
-
-# Add secrets
-sudo baudbot config
-
-# Deploy config/source snapshot to runtime
+# deploy latest source/config to runtime
 sudo baudbot deploy
 
-# Launch
-sudo -u baudbot_agent ~/runtime/start.sh
-```
-See [CONFIGURATION.md](CONFIGURATION.md) for the full list of secrets and how to obtain them.
-</details>
+# start the service
+sudo baudbot start
 
-## Configuration
-
-Secrets live in `~baudbot_agent/.config/.env` (not in repo, 600 perms).
-See [CONFIGURATION.md](CONFIGURATION.md) for all keys and how to obtain each value.
-
-## Agents
-
-Baudbot ships three agent roles. The control agent starts automatically and spawns the others in tmux sessions.
-
-| Role | What it does |
-|------|-------------|
-| **control-agent** | Monitors email inbox, triages requests, delegates to workers, runs Slack bridge |
-| **dev-agent** | Full coding loop: branch, code, test, PR, fix CI, repeat |
-| **sentry-agent** | Watches Sentry alerts, investigates via API, reports triage to control agent |
-
-Agents can read/write files, run shell commands, create git branches and PRs, build Docker images (via a security wrapper), message each other across sessions, monitor email inboxes, automate cloud browsers, and manage shared todos.
-
-## Integrations
-
-| Integration | How |
-|---|---|
-| **Slack** | Socket Mode bridge. @mentions + channel monitoring. Rate-limited, content-wrapped. |
-| **GitHub** | SSH + PAT. Branches, commits, PRs via `gh`. |
-| **Email** | AgentMail inboxes. Send, receive, monitor. |
-| **Sentry** | API integration. Alert forwarding from Slack channel. |
-| **Docker** | Security wrapper blocks privilege escalation. |
-| **Cloud browser** | Kernel browser + Playwright automation. |
-
-Slack is the primary human interface. Email is for agent-to-agent and automated workflows.
-
-## How it works
-
-The control agent spawns sub-agents in tmux sessions and starts the Slack bridge. Messages flow through layered security:
-
-```
-Slack → bridge (access control + content wrapping) → pi agent → tools (tool-guard + safe-bash) → workspace
+# check health
+sudo baudbot status
+sudo baudbot doctor
 ```
 
-Every layer assumes the previous one failed. The bridge wraps content and rate-limits, but tool-guard blocks dangerous commands even if wrapping is bypassed. Safe-bash blocks patterns even if tool-guard is evaded. The firewall blocks non-standard ports even if all software layers fail.
+See [CONFIGURATION.md](CONFIGURATION.md) for required environment variables and secret setup.
 
-### Heartbeat
+## Core agents
 
-The control agent runs a periodic heartbeat loop (default: every 10 minutes) that checks system health:
+| Role | Purpose |
+|------|---------|
+| **control-agent** | Owns intake, triage, delegation, Slack/email comms, and lifecycle supervision |
+| **dev-agent** | Ephemeral coding worker that executes branch → code → PR → CI loops |
+| **sentry-agent** | On-demand incident investigator for Sentry alerts and triage support |
 
-- Are all agent sessions alive?
-- Is the Slack bridge responsive?
-- Is the email monitor running?
-- Are there stale worktrees or stuck todos?
+## Architecture at a glance
 
-The checklist lives in `HEARTBEAT.md` — edit it to add custom checks. The heartbeat extension (`heartbeat.ts`) handles scheduling, error backoff, and the `heartbeat` tool for runtime control. If the checklist is empty, no heartbeat fires (saves tokens).
-### Persistent Memory
-
-Agents maintain persistent memory across session restarts via Markdown files in `~/.pi/agent/memory/`:
-
-| File | What it stores |
-|------|---------------|
-| `operational.md` | Infrastructure learnings, common errors and fixes |
-| `repos.md` | Per-repo build quirks, CI gotchas, architecture notes |
-| `users.md` | User preferences, timezone, communication style |
-| `incidents.md` | Past incidents: what broke, root cause, how it was fixed |
-
-Memory files are agent-owned — agents read them on startup and update them as they learn. Deploy seeds the files on first install but never overwrites existing content.
-
-## Architecture
-
-```
-admin_user (your account)
-├── ~/baudbot/                    ← source repo (agent CANNOT read)
-│   ├── bin/                         deploy, firewall, security scripts
-│   ├── pi/extensions/               🔒 tool-guard, auto-name, etc.
-│   ├── pi/skills/                   agent skill templates
-│   ├── slack-bridge/                🔒 bridge + security module
-│   └── setup.sh / start.sh          system setup + launcher
-
-root-owned operational releases (git-free)
-├── /opt/baudbot/
-│   ├── releases/<sha>/              immutable snapshot (no .git)
-│   ├── current -> releases/<sha>    active release symlink
-│   └── previous -> releases/<sha>   previous release symlink
-
-baudbot_agent (unprivileged uid)
-├── ~/runtime/                       deployed copies used at runtime
-├── ~/.pi/agent/
-│   ├── extensions/                  deployed extensions (read-only)
-│   ├── skills/                      agent-owned (can modify)
-│   ├── HEARTBEAT.md                 periodic health check checklist
-│   ├── memory/                      persistent agent memory (agent-owned)
-│   └── baudbot-manifest.json        SHA256 integrity hashes
-├── ~/workspace/                     project repos + worktrees
-└── ~/.config/.env                   secrets (600 perms)
+```text
+Slack/Email
+   ↓
+control-agent (always-on)
+   ├─ todo + routing
+   ├─ dev-agent(s) in isolated worktrees
+   └─ sentry-agent for incident triage
+        ↓
+git commits, PRs, CI feedback, thread updates
 ```
 
-`baudbot update` creates a temp checkout (`/tmp/baudbot-update.*`), runs preflight checks, publishes a git-free snapshot to `/opt/baudbot/releases/<sha>`, deploys runtime files, then atomically switches `/opt/baudbot/current` on success.
+Baudbot uses source/runtime separation: admin-managed source and immutable releases are deployed into an unprivileged agent runtime.
 
-## Control Plane
+## Security as an enabling layer
 
-Admin-owned web server for monitoring agent status and configuration. Runs on port 28800 — intentionally outside the agent's firewall allowlist so the agent cannot reach it.
+Baudbot is built for utility **and** containment:
 
-```bash
-# Start the control plane (runs as admin, NOT as baudbot_agent)
-~/baudbot/bin/control-plane.sh
+- isolated `baudbot_agent` Unix user (no general sudo)
+- per-UID firewall controls + process isolation
+- source/runtime separation with deploy manifests
+- read-only protection for security-critical files
+- layered tool and shell guardrails
 
-# Or in tmux alongside the agent
-tmux new-window -n control-plane '~/baudbot/bin/control-plane.sh'
+See [SECURITY.md](SECURITY.md) for full threat model, trust boundaries, and known risks.
 
-# With auth token (recommended)
-BAUDBOT_CP_TOKEN=$(openssl rand -hex 32) ~/baudbot/bin/control-plane.sh
-```
+## Documentation
 
-Open `http://127.0.0.1:28800/dashboard` for the web UI, or use the JSON API:
+- [docs/team-workflow.md](docs/team-workflow.md) — request lifecycle and orchestration model
+- [docs/agents.md](docs/agents.md) — agent roles, responsibilities, and session model
+- [docs/memory.md](docs/memory.md) — persistent memory design and operating rules
+- [docs/linux-runtime.md](docs/linux-runtime.md) — Linux execution model, tools, and constraints
+- [docs/operations.md](docs/operations.md) — day-2 operations (start/stop/update/rollback/audit)
+- [docs/architecture.md](docs/architecture.md) — source/runtime/release architecture
+- [CONFIGURATION.md](CONFIGURATION.md) — full env var reference
+- [SECURITY.md](SECURITY.md) — deep security model and vulnerability reporting
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contribution workflow
 
-```bash
-curl http://127.0.0.1:28800/health          # liveness (no auth)
-curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:28800/status    # agent status
-curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:28800/config    # config (secrets redacted)
-```
-
-## Operations
-
-```bash
-# Update live bot from upstream (temp checkout -> /opt release snapshot -> deploy)
-sudo baudbot update
-
-# Roll back live bot to the previous snapshot
-sudo baudbot rollback previous
-
-# Deploy source/config from current active release
-sudo baudbot deploy
-
-# Launch agent (tmux for persistence)
-tmux new-window -n baudbot 'sudo -u baudbot_agent ~/runtime/start.sh'
-
-# Security audit
-~/baudbot/bin/security-audit.sh
-~/baudbot/bin/security-audit.sh --deep   # includes extension scanner
-
-# Monitor agent sessions
-sudo -u baudbot_agent tmux ls
-
-# Kill everything
-sudo -u baudbot_agent pkill -u baudbot_agent
-
-# Uninstall
-sudo ~/baudbot/bin/uninstall.sh --dry-run   # preview
-sudo ~/baudbot/bin/uninstall.sh             # for real
-
-# Check deployed version
-sudo -u baudbot_agent cat ~/.pi/agent/baudbot-version.json
-```
 ## Tests
 
 ```bash
@@ -224,37 +134,6 @@ bin/test.sh shell
 # Lint + typecheck
 npm run lint && npm run typecheck
 ```
-
-## Adding agents
-
-An agent role is a skill file. Baudbot ships three but you can add more.
-
-1. Create `pi/skills/my-agent/SKILL.md` with role instructions.
-2. Add a tmux session spawn for the new agent in `pi/skills/control-agent/SKILL.md` (the control agent manages sub-agent lifecycle).
-3. Deploy: `sudo baudbot deploy`
-
-See `pi/skills/dev-agent/SKILL.md` for the pattern.
-
-## Security stack
-
-| Layer | What | Survives prompt injection? |
-|-------|------|---------------------------|
-| **Source isolation** | Source repo is admin-owned. Agent has zero read access. Live `/opt/baudbot/releases/*` snapshots are git-free immutable artifacts. | ✅ Filesystem |
-| **iptables egress** | Per-UID port allowlist (80/443/22/53 + DB ports). Blocks non-standard ports, listeners, raw sockets. | ✅ Kernel |
-| **Process isolation** | `/proc` mounted `hidepid=2`. Agent can't see other PIDs. | ✅ Kernel |
-| **File permissions** | Security-critical files deployed `chmod a-w`. Agent can't modify `tool-guard.ts`, `security.mjs`, etc. even via `sed` or `python`. | ✅ Filesystem |
-| **Shell deny list** | `baudbot-safe-bash` blocks rm -rf, reverse shells, fork bombs, curl\|sh. Root-owned. Pattern-based — can't catch everything. | ✅ Root-owned |
-| **Tool interception** | Pi extension blocks Edit/Write tools outside agent home + known dangerous bash patterns. Audit-logs all tool calls. Does NOT prevent arbitrary file writes through bash (that's what file permissions are for). | ✅ Read-only |
-| **Integrity manifest** | Deploy stamps SHA256 hashes. Security audit verifies runtime files match. | ✅ Admin-signed |
-| **Content wrapping** | External messages wrapped with security boundaries + homoglyph sanitization. | ⚠️ LLM-dependent |
-| **Injection detection** | 12 regex patterns flag suspicious content. Log-only. | ⚠️ Detection only |
-| **Filesystem hardening** | 700 dirs, 600 secrets, enforced on every boot. | ✅ Boot script |
-| **Log redaction** | Scrubs API keys, tokens, private keys from session logs. | ✅ Boot script |
-| **Extension scanning** | Static analysis for exfiltration, obfuscation, crypto-mining patterns. | ✅ Audit-time |
-
-## Security details
-
-See [SECURITY.md](SECURITY.md) for the full threat model and trust boundary diagram.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security
 
+For product overview and team workflow context, start with [README.md](README.md). For architecture and operations docs, see [`docs/architecture.md`](docs/architecture.md) and [`docs/operations.md`](docs/operations.md).
+
 ## Architecture: Source / Runtime Separation
 
 ```

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,79 @@
+# Agents
+
+Baudbot uses a small multi-agent architecture: one persistent orchestrator and task-scoped workers. This keeps the team-facing interface stable while allowing parallel execution in the background.
+
+## Role overview
+
+| Agent | Lifecycle | Primary responsibility |
+|------|-----------|------------------------|
+| `control-agent` | Persistent | Intake, triage, delegation, user communication, orchestration |
+| `dev-agent` | Ephemeral per task | Code changes, tests, PRs, CI/review iteration |
+| `sentry-agent` | Persistent/on-demand | Sentry alert triage and investigation support |
+
+## Control-agent
+
+The control-agent is the team-facing coordinator.
+
+Responsibilities:
+
+- monitor inbound requests (Slack/email)
+- create and manage todos
+- select target repo(s)
+- spawn and supervise dev-agent sessions
+- relay progress/results to users
+- enforce operational guardrails (cleanup, escalation)
+
+It should remain lightweight on coding itself and focus on orchestration quality.
+
+## Dev-agent
+
+The dev-agent is a coding worker launched in a dedicated git worktree for each task.
+
+Responsibilities:
+
+- read project guidance (`CODEX.md`, `AGENTS.md`, `CLAUDE.md` as available)
+- implement requested changes
+- run tests/build checks
+- open PR and monitor CI
+- fix failures and address review comments
+- report completion details back to control-agent
+
+Each dev-agent is task-scoped and should exit when work is done.
+
+## Sentry-agent
+
+The sentry-agent handles incident-oriented analysis.
+
+Responsibilities:
+
+- investigate Sentry issues by issue ID
+- summarize likely impact and root cause
+- provide actionable recommendations for fixes
+- hand off coding tasks to dev-agent through control-agent
+
+## Session model
+
+- Control and sentry sessions are long-lived.
+- Dev sessions are ephemeral and tied to todos.
+- Session-control sockets allow inter-agent messaging (`send_to_session`).
+- Naming conventions encode role and task context (for observability and cleanup).
+
+## Concurrency
+
+Baudbot limits concurrent dev agents to keep resource usage predictable and avoid context thrash.
+
+Use this model when scaling:
+
+- keep a fixed max active dev-agent count
+- queue additional tasks
+- prioritize by urgency or user/channel policy
+
+## Communication contract
+
+- **Users talk to control-agent**
+- **Dev-agent reports to control-agent**
+- **Control-agent reports back to users**
+
+This keeps the external interface stable while allowing internal execution strategies to evolve.
+
+For flow details, see [team-workflow.md](team-workflow.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,62 @@
+# Architecture
+
+Baudbot separates admin-owned source from agent-owned runtime to reduce blast radius while still enabling always-on autonomous execution.
+
+## Source / release / runtime layout
+
+```text
+admin user
+├── ~/baudbot/                     # source repo (admin-owned)
+│   ├── bin/
+│   ├── pi/extensions/
+│   ├── pi/skills/
+│   └── slack-bridge/
+
+root-managed releases
+├── /opt/baudbot/
+│   ├── releases/<sha>/            # immutable, git-free snapshots
+│   ├── current -> releases/<sha>
+│   └── previous -> releases/<sha>
+
+baudbot_agent user
+├── ~/runtime/                     # deployed runtime used by live agent
+├── ~/.pi/agent/                   # skills/extensions/memory/manifests
+└── ~/workspace/                   # project repos + task worktrees
+```
+
+## Deployment flow
+
+1. Admin updates source repo.
+2. Deploy/update scripts build a staged snapshot.
+3. Snapshot is published to `/opt/baudbot/releases/<sha>`.
+4. Runtime files are deployed for `baudbot_agent`.
+5. Symlink switch (`current`) is updated atomically on success.
+
+This allows reproducible releases and fast rollback.
+
+## Agent topology
+
+```text
+control-agent (persistent)
+├── sentry-agent (persistent/on-demand)
+└── dev-agent-* (ephemeral task workers)
+```
+
+Inter-session communication is handled over pi session-control sockets.
+
+## Data path summary
+
+```text
+Slack/Email → bridge + wrapping → control-agent
+            → todo + delegation → dev-agent worktree execution
+            → PR/CI outcomes → control-agent response in source thread
+```
+
+## Why this architecture
+
+- clear trust boundaries between admin and agent runtime
+- predictable operations for deploy/update/rollback
+- support for concurrent, task-scoped coding workers
+- safer enablement of high-privilege tools via layered controls
+
+For security controls and known risks, see [../SECURITY.md](../SECURITY.md).

--- a/docs/linux-runtime.md
+++ b/docs/linux-runtime.md
@@ -1,0 +1,58 @@
+# Linux Runtime
+
+Baudbot is designed to run as Linux-native infrastructure, not a browser-only assistant, so it can execute against your real stack instead of a simulated environment.
+
+## Execution model
+
+- runs as unprivileged `baudbot_agent` user
+- operates in real filesystem workspaces and git worktrees
+- executes shell commands, test suites, and build pipelines directly
+- supports container workflows via guarded Docker wrapper
+
+## What this enables for teams
+
+- run actual project commands (lint/test/build/migrate)
+- validate fixes against real local/runtime dependencies
+- automate browser tasks through cloud browser tooling
+- handle long-running operational loops in tmux/systemd
+
+## Docker support
+
+Agents must use:
+
+```bash
+sudo /usr/local/bin/baudbot-docker
+```
+
+This wrapper blocks common privilege-escalation patterns (for example, privileged mode and unsafe host mounts).
+
+## Process and workspace model
+
+```text
+/home/baudbot_agent/
+├── runtime/           # deployed runtime files
+├── .pi/agent/         # extensions, skills, memory, manifests
+└── workspace/         # repos + git worktrees used by dev agents
+```
+
+Dev agents work inside `~/workspace/worktrees/<branch>` and should not commit directly from base repo checkouts.
+
+## Platform support
+
+Validated in CI against:
+
+- Ubuntu 24.04
+- Arch Linux
+
+Baudbot scripts aim to remain distro-agnostic across standard Linux environments.
+
+## Operational boundaries
+
+Linux-native does not mean unrestricted root access:
+
+- no general sudo for agents
+- security-critical files are read-only at runtime
+- network controls can restrict outbound traffic
+- source/runtime separation limits self-tampering blast radius
+
+See [SECURITY.md](../SECURITY.md) for threat model details.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,64 @@
+# Persistent Memory
+
+Baudbot uses file-based memory so context survives session restarts and knowledge compounds at the team level.
+
+## Memory location
+
+Memory files live in the deployed runtime under:
+
+```text
+~/.pi/agent/memory/
+```
+
+Typical files:
+
+- `operational.md` — infra learnings and recurring fixes
+- `repos.md` — per-repo build/CI quirks and notes
+- `users.md` — collaboration preferences and communication style
+- `incidents.md` — prior incidents, root cause, and resolution
+
+## Why it matters
+
+Persistent memory lets the system improve over time:
+
+- fewer repeated mistakes
+- faster triage for recurring failures
+- better continuity across restarts or model/session swaps
+
+## Operating rules
+
+- Read memory on startup before executing new work.
+- Append new learnings with dated entries.
+- Keep entries concrete and action-oriented.
+- Never store secrets, API keys, tokens, or private credentials.
+
+## Entry format (example)
+
+```markdown
+## 2026-02-18
+- Repo: myapp
+- Finding: integration tests fail unless REDIS_URL is set explicitly in CI.
+- Fix: export REDIS_URL=redis://127.0.0.1:6379 before running test:integration.
+```
+
+## What belongs in memory vs git docs
+
+Use memory for:
+
+- runtime observations
+- team preferences
+- temporary but useful operational context
+
+Use repository docs/commits for:
+
+- canonical architecture
+- long-term implementation docs
+- user-facing product behavior changes
+
+## Maintenance
+
+- prune stale or duplicated notes periodically
+- keep headings consistent for scanability
+- consolidate repeated points into single authoritative entries
+
+For role behavior around memory usage, see [agents.md](agents.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,97 @@
+# Operations
+
+Day-2 operations for running Baudbot in production-like environments with predictable deploy, rollback, and health-check workflows.
+
+## Core lifecycle commands
+
+```bash
+# Start / stop / restart service
+sudo baudbot start
+sudo baudbot stop
+sudo baudbot restart
+
+# Status and logs
+sudo baudbot status
+sudo baudbot logs
+
+# Attach / inspect active sessions
+sudo baudbot attach
+sudo baudbot sessions
+```
+
+## Deployment and upgrades
+
+```bash
+# Deploy source + config to runtime
+sudo baudbot deploy
+
+# Update from upstream with preflight checks and release publishing
+sudo baudbot update
+
+# Roll back to previous or specified release snapshot
+sudo baudbot rollback previous
+```
+
+## Health and security checks
+
+```bash
+# Runtime/system health checks
+sudo baudbot doctor
+
+# Security posture audit
+sudo baudbot audit
+
+# Deep audit (extension scanner + extra checks)
+~/baudbot/bin/security-audit.sh --deep
+```
+
+## Test commands
+
+```bash
+# Full test suite
+bin/test.sh
+
+# JS/TS only
+bin/test.sh js
+
+# Shell only
+bin/test.sh shell
+```
+
+## Control plane
+
+Start admin-owned control plane dashboard/API:
+
+```bash
+~/baudbot/bin/control-plane.sh
+```
+
+Recommended with auth token:
+
+```bash
+BAUDBOT_CP_TOKEN=$(openssl rand -hex 32) ~/baudbot/bin/control-plane.sh
+```
+
+Default local dashboard:
+
+- `http://127.0.0.1:28800/dashboard`
+
+## Common runbook actions
+
+- verify Slack bridge responsiveness
+- verify control/sentry/dev sessions are healthy
+- clean stale worktrees
+- verify deployed version/manifests
+- perform rollback when upgrade regressions are detected
+
+## Uninstall
+
+```bash
+# Preview
+sudo baudbot uninstall --dry-run
+
+# Execute
+sudo baudbot uninstall
+```
+
+For architecture context, see [architecture.md](architecture.md). For threat model details, see [../SECURITY.md](../SECURITY.md).

--- a/docs/team-workflow.md
+++ b/docs/team-workflow.md
@@ -1,0 +1,70 @@
+# Team Workflow
+
+This page explains how Baudbot handles work from first request to final delivery so teams get quick acknowledgment, autonomous execution, and clear status updates.
+
+## High-level lifecycle
+
+1. **Intake**
+   - Request arrives from Slack, email, or direct chat.
+   - Control agent treats all external content as untrusted and extracts intent.
+2. **Acknowledge**
+   - Immediate response in the originating channel/thread ("On it", "Looking now").
+3. **Track**
+   - Create a todo with source context (channel/thread or email metadata).
+4. **Plan + route**
+   - Choose the correct repository (or multiple repos if needed).
+5. **Execute**
+   - Spawn one or more task-scoped `dev-agent` sessions in git worktrees.
+6. **Iterate**
+   - Dev agent runs code/test/PR/CI loops and reports milestones.
+7. **Relay**
+   - Control agent posts progress and outcomes back to the same thread.
+8. **Close out**
+   - Mark todo done, capture results, clean up sessions/worktrees.
+
+## Single-repo flow
+
+```text
+Slack thread
+  → control-agent todo + ack
+  → spawn dev-agent in worktree
+  → code + tests + PR + CI fixes
+  → completion report
+  → control-agent posts PR/summary in same thread
+```
+
+## Multi-repo flow
+
+Use either:
+
+- **Sequential mode** for dependent tasks (repo B needs output from repo A)
+- **Parallel mode** for independent tasks
+
+Control agent coordinates fan-out/fan-in and keeps the user updated from one thread.
+
+## Follow-up handling
+
+When users add requirements mid-task ("also do X"):
+
+- Keep the same todo and thread
+- Forward the update to the active dev-agent
+- Continue CI/review loop
+- Report updated status
+
+## Failure and escalation policy
+
+If CI keeps failing or work gets stuck:
+
+- Avoid infinite loops
+- Post a clear status update with blocker context
+- Ask the user to decide next step (scope cut, rollback, manual handoff)
+- Preserve state in todo notes
+
+## Operational expectations
+
+- Always reply in-thread for Slack work
+- Keep user-facing updates concise and frequent
+- Prefer practical artifacts in status updates (PR link, failing check, preview URL)
+- Clean up ephemeral resources after completion
+
+For role-level behavior details, see [agents.md](agents.md). For commands and runbook tasks, see [operations.md](operations.md).


### PR DESCRIPTION
## Summary
- rewrite README to lead with what Baudbot does for developer teams (always-on, multiplayer, Linux-native execution, persistent memory)
- add a concrete end-to-end workflow example (Slack request → dev agent → PR/CI → thread update)
- condense security coverage in README and position it as enabling infrastructure
- add deep-dive docs pages under docs/ for workflow, agents, memory, runtime, operations, and architecture
- add cross-links in CONTRIBUTING/SECURITY and update AGENTS docs-update guidance

## Notes
- docs-only change
- no runtime behavior changes