### PR TITLE
feat: add Linear integration extension

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -96,6 +96,13 @@ SLACK_CHANNEL_ID=
 # @docs(https://kernel.computer)
 KERNEL_API_KEY=
 
+# ── Linear (optional) ────────────────────────────────────────────────────────
+
+# Linear API key (personal or OAuth token)
+# @type=string
+# @docs(https://linear.app/settings/api)
+LINEAR_API_KEY=
+
 # ── Tool Guard ───────────────────────────────────────────────────────────────
 
 # Unix username of the agent

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,6 +60,14 @@ The agent also uses an SSH key (`~/.ssh/id_ed25519`) for git push. Setup generat
 | `SENTRY_ORG` | Sentry organization slug | The slug from your Sentry URL: `sentry.io/organizations/<this-part>/` |
 | `SENTRY_CHANNEL_ID` | Slack channel ID for Sentry alerts | The Slack channel where Sentry posts alerts. Right-click the channel → "View channel details" → scroll to the bottom for the Channel ID. |
 
+### Linear Integration
+
+The `linear` extension provides a tool for interacting with the Linear issue tracker. The agent can search, list, create, update, and comment on issues via Linear's GraphQL API.
+
+| Variable | Description | How to get it |
+|----------|-------------|---------------|
+| `LINEAR_API_KEY` | Linear API key (personal or OAuth token) | Go to [Linear Settings → API](https://linear.app/settings/api), create a **Personal API key**. For workspace-wide access, create an OAuth application instead. The key needs read/write access to issues and comments. |
+
 ### Slack Channels
 
 | Variable | Description | How to get it |
@@ -154,6 +162,9 @@ BAUDBOT_ALLOWED_EMAILS=you@example.com
 # Sentry (optional)
 SENTRY_AUTH_TOKEN=sntrys_...
 SENTRY_ORG=my-org
+
+# Linear (optional)
+LINEAR_API_KEY=lin_api_...
 
 # Kernel (optional)
 KERNEL_API_KEY=...


### PR DESCRIPTION
Adds `pi/extensions/linear.ts` — a new pi extension providing a `linear` tool for interacting with the Linear issue tracker via their GraphQL API.

## Actions
- **search** — Text search for issues with optional status filter
- **get** — Full issue details by identifier (e.g. MOD-123) including description, labels, and last 5 comments
- **list** — List issues with filters (status, assignee, team, label)
- **create** — Create a new issue (title + team_id required)
- **update** — Update issue status, priority, or assignee
- **comment** — Add a comment to an issue

## Implementation
- Uses Linear's GraphQL API at `https://api.linear.app/graphql`
- Auth via `LINEAR_API_KEY` env var
- No external deps — uses built-in `fetch`
- Token-efficient: returns compact pre-formatted text, not raw JSON
- Follows the same `registerTool` pattern as `sentry-monitor.ts`
- Resolves human-readable identifiers (MOD-123) to UUIDs via `issueSearch` for mutations