### PR TITLE
cli: default attach target to control-agent

### DIFF
--- a/bin/baudbot
+++ b/bin/baudbot
@@ -435,6 +435,7 @@ case "${1:-}" in
   attach)
     shift
     require_root "attach"
+    AGENT_USER="baudbot_agent"
     AGENT_HOME="/home/$AGENT_USER"
 
     ATTACH_MODE="auto"


### PR DESCRIPTION
## Summary
- make `baudbot attach` default to `control-agent` instead of the first tmux session
- in auto mode, prefer matching pi session first (control-agent by default), then tmux fallback
- keep `--pi` and `--tmux` explicit modes for advanced use
- update attach help text to reflect the new default

## Why
This avoids attaching to unrelated sessions (for example, slack-bridge/sentry) when users expect to watch the main control-agent conversation.

## Testing
- `bash -n bin/baudbot`
- `bin/test.sh shell`