### PR TITLE
docs: add minimal upgrade steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Upgrade later:
 
 ```bash
 sudo baudbot update
-sudo baudbot status
-sudo baudbot doctor
 ```
 
 See [CONFIGURATION.md](CONFIGURATION.md) for required environment variables and secret setup.


### PR DESCRIPTION
## Summary
- add a small "Upgrade later" block under the Quick Start commands in README
- include minimal upgrade + health check commands

## Testing
- docs-only change