### PR TITLE
security: prune old session logs on startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ bin/                        security & operations scripts
   harden-permissions.sh     filesystem hardening (runs on boot)
   scan-extensions.mjs       extension static analysis
   redact-logs.sh            secret scrubber for session logs
+  prune-session-logs.sh     retention cleanup for old pi session logs
   config.sh                 env var validation helper
   control-plane.sh          starts the admin web dashboard
   doctor.sh                 system health checks
@@ -98,7 +99,7 @@ Agent runtime layout:
 /home/baudbot_agent/
 ├── runtime/
 │   ├── start.sh                deployed launcher
-│   ├── bin/                    harden-permissions.sh, redact-logs.sh
+│   ├── bin/                    harden-permissions.sh, redact-logs.sh, prune-session-logs.sh
 │   └── slack-bridge/           deployed bridge
 ├── .pi/agent/
 │   ├── extensions/             deployed extensions
@@ -205,7 +206,7 @@ The CI scripts (`bin/ci/setup-ubuntu.sh`, `bin/ci/setup-arch.sh`) run `install.s
 - The firewall (`setup-firewall.sh`) restricts `baudbot_agent`'s network egress to an allowlist.
 - `/proc` is mounted with `hidepid=2` — agent can only see its own processes.
 - Secrets in `~/.config/.env` are `600` perms, never committed.
-- Session logs are auto-redacted of API keys/tokens on boot.
+- Session logs are auto-pruned on startup (14-day retention) and auto-redacted for API keys/tokens.
 
 ## Git Workflow
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -184,3 +184,5 @@ sudo baudbot restart
 ```
 
 The bridge and all sub-agents load `~/.config/.env` on startup. If varlock is installed, variables are validated against `.env.schema` before injection.
+
+Session logs are pruned on startup with a default 14-day retention window (`~/runtime/bin/prune-session-logs.sh --days 14`) and then redacted for common secret patterns.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Baudbot is built for utility **and** containment:
 - per-UID firewall controls + process isolation
 - source/runtime separation with deploy manifests
 - read-only protection for security-critical files
+- session log hygiene (startup redaction + retention pruning)
 - layered tool and shell guardrails
 
 See [SECURITY.md](SECURITY.md) for full threat model, trust boundaries, and known risks.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,8 +152,8 @@ Even with port-based firewall rules, the agent can reach any host over HTTPS. Da
 ### Content wrapping is a soft defense
 The `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` boundaries and security notice ask the LLM to ignore injected instructions. This raises the bar but is not a hard security boundary.
 
-### Session logs contain full history
-Pi session logs (`.jsonl` files) contain the complete conversation history. If permissions are not hardened (see `bin/harden-permissions.sh`), these are group-readable.
+### Session logs are sensitive transcripts
+Pi session logs (`.jsonl` files) contain full conversation transcripts for retained sessions. Baudbot now prunes old logs on startup (14-day retention) and redacts common secret patterns, but retained logs are still sensitive data and should stay owner-only (see `bin/harden-permissions.sh`).
 
 ## Security Scripts
 
@@ -162,6 +162,7 @@ Pi session logs (`.jsonl` files) contain the complete conversation history. If p
 | `bin/security-audit.sh` | Check current security posture + integrity checks | baudbot_agent or admin |
 | `bin/deploy.sh` | Deploy from source to runtime with correct permissions | root or admin |
 | `bin/harden-permissions.sh` | Lock down pi state file permissions | baudbot_agent |
+| `bin/prune-session-logs.sh` | Delete old pi session transcripts (retention cleanup) | baudbot_agent |
 | `bin/setup-firewall.sh` | Apply port-based network restrictions | root |
 
 ## Reporting Vulnerabilities

--- a/bin/baudbot.service
+++ b/bin/baudbot.service
@@ -9,8 +9,9 @@ User=baudbot_agent
 Group=baudbot_agent
 WorkingDirectory=/home/baudbot_agent
 
-# Pre-start: lock down perms and scrub secrets from old logs
+# Pre-start: lock down perms, prune old logs, and scrub leaked secrets
 ExecStartPre=/home/baudbot_agent/runtime/bin/harden-permissions.sh
+ExecStartPre=/bin/bash -c '/home/baudbot_agent/runtime/bin/prune-session-logs.sh --days 14 2>/dev/null || true'
 ExecStartPre=/bin/bash -c '/home/baudbot_agent/runtime/bin/redact-logs.sh 2>/dev/null || true'
 
 # Main process

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -48,7 +48,7 @@ if [ "$DRY_RUN" -eq 0 ]; then
   cp -r --no-preserve=ownership "$BAUDBOT_SRC/slack-bridge" "$STAGE_DIR/slack-bridge"
   cp --no-preserve=ownership "$BAUDBOT_SRC/start.sh" "$STAGE_DIR/start.sh"
   mkdir -p "$STAGE_DIR/bin"
-  for script in harden-permissions.sh redact-logs.sh; do
+  for script in harden-permissions.sh redact-logs.sh prune-session-logs.sh; do
     [ -f "$BAUDBOT_SRC/bin/$script" ] && cp --no-preserve=ownership "$BAUDBOT_SRC/bin/$script" "$STAGE_DIR/bin/$script"
   done
   [ -f "$BAUDBOT_SRC/pi/settings.json" ] && cp --no-preserve=ownership "$BAUDBOT_SRC/pi/settings.json" "$STAGE_DIR/settings.json"
@@ -223,7 +223,7 @@ echo "Deploying runtime scripts..."
 if [ "$DRY_RUN" -eq 0 ]; then
   as_agent mkdir -p "$BAUDBOT_HOME/runtime/bin"
 
-  for script in harden-permissions.sh redact-logs.sh; do
+  for script in harden-permissions.sh redact-logs.sh prune-session-logs.sh; do
     if [ -f "$STAGE_DIR/bin/$script" ]; then
       as_agent cp "$STAGE_DIR/bin/$script" "$BAUDBOT_HOME/runtime/bin/$script"
       as_agent chmod u+x "$BAUDBOT_HOME/runtime/bin/$script"

--- a/bin/prune-session-logs.sh
+++ b/bin/prune-session-logs.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Prune old pi session logs to reduce sensitive transcript retention.
+#
+# Deletes *.jsonl files under ~/.pi/agent/sessions older than N days,
+# then removes empty session directories.
+#
+# Usage: ~/baudbot/bin/prune-session-logs.sh [--days N] [--dry-run]
+# Default retention: 14 days
+
+set -euo pipefail
+
+RETENTION_DAYS=14
+DRY_RUN=0
+
+usage() {
+  echo "Usage: $0 [--days N] [--dry-run]"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --days)
+      [ "$#" -lt 2 ] && { usage; exit 2; }
+      RETENTION_DAYS="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ! echo "$RETENTION_DAYS" | grep -Eq '^[0-9]+$'; then
+  echo "Invalid --days value: $RETENTION_DAYS (must be a non-negative integer)" >&2
+  exit 2
+fi
+
+SESSION_DIR="${HOME}/.pi/agent/sessions"
+
+if [ ! -d "$SESSION_DIR" ]; then
+  echo "No sessions directory found at $SESSION_DIR"
+  exit 0
+fi
+
+deleted_logs=0
+deleted_dirs=0
+scanned_logs=0
+
+while IFS= read -r -d '' logfile; do
+  scanned_logs=$((scanned_logs + 1))
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "WOULD DELETE: $logfile"
+    deleted_logs=$((deleted_logs + 1))
+    continue
+  fi
+
+  rm -f "$logfile"
+  echo "  ✓ Deleted log: $logfile"
+  deleted_logs=$((deleted_logs + 1))
+done < <(find "$SESSION_DIR" -type f -name '*.jsonl' -mtime +"$RETENTION_DAYS" -print0 2>/dev/null)
+
+while IFS= read -r -d '' dir; do
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "WOULD DELETE EMPTY DIR: $dir"
+    deleted_dirs=$((deleted_dirs + 1))
+    continue
+  fi
+
+  rmdir "$dir" 2>/dev/null || true
+  if [ ! -d "$dir" ]; then
+    echo "  ✓ Deleted empty dir: $dir"
+    deleted_dirs=$((deleted_dirs + 1))
+  fi
+done < <(find "$SESSION_DIR" -mindepth 1 -type d -empty -print0 2>/dev/null)
+
+echo ""
+echo "Session log pruning complete"
+echo "  Retention days: $RETENTION_DAYS"
+echo "  Old logs found: $scanned_logs"
+echo "  Logs deleted: $deleted_logs"
+echo "  Empty dirs deleted: $deleted_dirs"
+
+if [ "$DRY_RUN" -eq 1 ] && [ "$deleted_logs" -gt 0 ]; then
+  echo ""
+  echo "  (dry run — no files were modified)"
+fi

--- a/bin/prune-session-logs.test.sh
+++ b/bin/prune-session-logs.test.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Tests for prune-session-logs.sh
+#
+# Run: bash prune-session-logs.test.sh
+
+set -euo pipefail
+
+SCRIPT="$(dirname "$0")/prune-session-logs.sh"
+PASS=0
+FAIL=0
+
+TMPDIR=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+expect_exists() {
+  local desc="$1"
+  local path="$2"
+  if [ -e "$path" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+expect_not_exists() {
+  local desc="$1"
+  local path="$2"
+  if [ ! -e "$path" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+expect_contains() {
+  local desc="$1"
+  local output="$2"
+  local pattern="$3"
+  if echo "$output" | grep -qF "$pattern"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "        expected to find: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "Testing prune-session-logs.sh"
+echo "============================="
+echo ""
+
+# ── Test 1: Deletes old logs, keeps recent logs ─────────────────────────────
+
+echo "Test: prune old logs only"
+HOME1="$TMPDIR/home1"
+SESS1="$HOME1/.pi/agent/sessions"
+mkdir -p "$SESS1/old-session" "$SESS1/recent-session"
+
+old_log="$SESS1/old-session/session.jsonl"
+recent_log="$SESS1/recent-session/session.jsonl"
+
+echo '{"msg":"old"}' > "$old_log"
+echo '{"msg":"recent"}' > "$recent_log"
+
+touch -d '30 days ago' "$old_log"
+touch -d '2 days ago' "$recent_log"
+
+output=$(HOME="$HOME1" bash "$SCRIPT" --days 14)
+expect_contains "reports pruning summary" "$output" "Session log pruning complete"
+expect_not_exists "old log deleted" "$old_log"
+expect_exists "recent log kept" "$recent_log"
+
+echo ""
+
+# ── Test 2: Removes empty dirs after deleting logs ──────────────────────────
+
+echo "Test: removes empty directories"
+expect_not_exists "empty old session dir removed" "$SESS1/old-session"
+expect_exists "recent session dir retained" "$SESS1/recent-session"
+
+echo ""
+
+# ── Test 3: Dry run does not modify files ───────────────────────────────────
+
+echo "Test: dry-run"
+HOME2="$TMPDIR/home2"
+SESS2="$HOME2/.pi/agent/sessions"
+mkdir -p "$SESS2/dry-run-session"
+
+dry_log="$SESS2/dry-run-session/session.jsonl"
+echo '{"msg":"dry"}' > "$dry_log"
+touch -d '45 days ago' "$dry_log"
+
+output=$(HOME="$HOME2" bash "$SCRIPT" --days 14 --dry-run)
+expect_contains "dry run announces would delete" "$output" "WOULD DELETE:"
+expect_exists "dry run keeps old log" "$dry_log"
+
+echo ""
+
+# ── Test 4: Missing sessions dir exits cleanly ──────────────────────────────
+
+echo "Test: missing sessions dir"
+HOME3="$TMPDIR/home3"
+mkdir -p "$HOME3"
+output=$(HOME="$HOME3" bash "$SCRIPT")
+expect_contains "missing dir handled" "$output" "No sessions directory found"
+
+echo ""
+
+# ── Test 5: Invalid days value fails ────────────────────────────────────────
+
+echo "Test: invalid --days"
+set +e
+HOME="$HOME1" bash "$SCRIPT" --days invalid >/dev/null 2>&1
+code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+  echo "  PASS: invalid days exits non-zero"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: invalid days should fail"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+  exit 0
+fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -75,6 +75,7 @@ run_shell_tests() {
   echo "Shell:"
   run "safe-bash wrapper"   bash bin/baudbot-safe-bash.test.sh
   run "log redaction"       bash bin/redact-logs.test.sh
+  run "log pruning"         bash bin/prune-session-logs.test.sh
   run "update release flow" bash bin/update-release.test.sh
   run "rollback release"    bash bin/rollback-release.test.sh
   echo ""

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -81,6 +81,7 @@ Default local dashboard:
 - verify Slack bridge responsiveness
 - verify control/sentry/dev sessions are healthy
 - clean stale worktrees
+- prune old session logs if needed (`sudo -u baudbot_agent ~/runtime/bin/prune-session-logs.sh --days 14`)
 - verify deployed version/manifests
 - perform rollback when upgrade regressions are detected
 

--- a/pi/skills/control-agent/HEARTBEAT.md
+++ b/pi/skills/control-agent/HEARTBEAT.md
@@ -7,3 +7,4 @@ Check each item and take action only if something is wrong.
 - Check email monitor is running (`email_monitor status` — should show active)
 - Check for stale worktrees in `~/workspace/worktrees/` that don't correspond to active in-progress todos — clean them up with `git worktree remove`
 - Check for stuck todos (status `in-progress` for more than 2 hours with no corresponding dev-agent session) — escalate to user via Slack
+- Optional: if disk usage is growing, prune old session logs (`~/runtime/bin/prune-session-logs.sh --days 14`)

--- a/start.sh
+++ b/start.sh
@@ -30,7 +30,10 @@ set +a
 umask 077
 ~/runtime/bin/harden-permissions.sh
 
-# Redact any secrets that leaked into session logs
+# Prune old session logs to limit transcript retention window
+~/runtime/bin/prune-session-logs.sh --days 14 2>/dev/null || true
+
+# Redact any secrets that leaked into retained session logs
 ~/runtime/bin/redact-logs.sh 2>/dev/null || true
 
 # Clean stale session sockets from previous runs


### PR DESCRIPTION
## Summary
- add `bin/prune-session-logs.sh` to delete old `~/.pi/agent/sessions/*.jsonl` files (default 14-day retention) and remove empty session directories
- run pruning at startup in both `start.sh` and `bin/baudbot.service` (`ExecStartPre`)
- deploy the pruning script to runtime via `bin/deploy.sh`
- add `bin/prune-session-logs.test.sh` and wire it into `bin/test.sh` shell tests
- update docs (`README.md`, `SECURITY.md`, `CONFIGURATION.md`, `docs/operations.md`, `AGENTS.md`, `pi/skills/control-agent/HEARTBEAT.md`)

## Testing
- `bash bin/prune-session-logs.test.sh`
- `bash bin/test.sh shell`
