### PR TITLE
bridge: default broker register URL to broker.baudbot.ai

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -52,6 +52,7 @@ sudo baudbot broker register \
 ```
 
 If `--broker-url` is omitted, baudbot defaults to `https://broker.baudbot.ai`.
+If `--callback-url` is omitted, baudbot defaults to `<broker-url>/slack/broker/callback`.
 
 `baudbot setup` is host provisioning only; do not use `baudbot setup --slack-broker`.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ sudo baudbot broker register \
 ```
 
 If `--broker-url` is omitted, baudbot defaults to `https://broker.baudbot.ai`.
+If `--callback-url` is omitted, baudbot defaults to `<broker-url>/slack/broker/callback`.
 
 See [CONFIGURATION.md](CONFIGURATION.md) for required environment variables and secret setup.
 

--- a/bin/baudbot
+++ b/bin/baudbot
@@ -584,11 +584,11 @@ case "${1:-}" in
         exec node "$BAUDBOT_ROOT/bin/broker-register.mjs" "$@"
         ;;
       --help|-h|"")
-        echo "Usage: sudo baudbot broker register [--broker-url URL(default: https://broker.baudbot.ai)] [--workspace-id ID] [--auth-code CODE] [--callback-url URL]"
+        echo "Usage: sudo baudbot broker register [--broker-url URL(default: https://broker.baudbot.ai)] [--workspace-id ID] [--auth-code CODE] [--callback-url URL(default: <broker-url>/slack/broker/callback)]"
         ;;
       *)
         echo "Unknown broker subcommand: ${1:-}"
-        echo "Usage: sudo baudbot broker register [--broker-url URL(default: https://broker.baudbot.ai)] [--workspace-id ID] [--auth-code CODE] [--callback-url URL]"
+        echo "Usage: sudo baudbot broker register [--broker-url URL(default: https://broker.baudbot.ai)] [--workspace-id ID] [--auth-code CODE] [--callback-url URL(default: <broker-url>/slack/broker/callback)]"
         exit 1
         ;;
     esac

--- a/bin/broker-register.test.mjs
+++ b/bin/broker-register.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import {
   DEFAULT_BROKER_URL,
+  DEFAULT_CALLBACK_PATH,
   parseArgs,
   normalizeBrokerUrl,
   validateWorkspaceId,
@@ -10,6 +11,8 @@ import {
   mapRegisterError,
   registerWithBroker,
   resolveBrokerUrlInput,
+  buildDefaultCallbackUrl,
+  resolveCallbackUrlInput,
   upsertEnvContent,
   runRegistration,
 } from "./broker-register.mjs";
@@ -63,6 +66,21 @@ test("resolveBrokerUrlInput prefers cli then existing then default", () => {
     "https://existing.example.com",
   );
   assert.equal(resolveBrokerUrlInput("", ""), DEFAULT_BROKER_URL);
+});
+
+test("resolveCallbackUrlInput prefers cli then existing then broker-derived default", () => {
+  assert.equal(
+    resolveCallbackUrlInput("https://cli.example.com/cb", "https://existing.example.com/cb", "https://broker.example.com"),
+    "https://cli.example.com/cb",
+  );
+  assert.equal(
+    resolveCallbackUrlInput("", "https://existing.example.com/cb", "https://broker.example.com"),
+    "https://existing.example.com/cb",
+  );
+
+  const derived = resolveCallbackUrlInput("", "", "https://broker.example.com");
+  assert.equal(derived, `https://broker.example.com${DEFAULT_CALLBACK_PATH}`);
+  assert.equal(buildDefaultCallbackUrl("https://broker.example.com/anything"), `https://broker.example.com${DEFAULT_CALLBACK_PATH}`);
 });
 
 test("validation helpers normalize and enforce broker/workspace/callback formats", () => {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -44,6 +44,7 @@ sudo baudbot broker register \
 ```
 
 If `--broker-url` is omitted, baudbot defaults to `https://broker.baudbot.ai`.
+If `--callback-url` is omitted, baudbot defaults to `<broker-url>/slack/broker/callback`.
 
 Do not use `baudbot setup --slack-broker` — `setup` is host provisioning only.
 


### PR DESCRIPTION
## Problem
`baudbot broker register` required `--broker-url` or an existing env value, even though we have a canonical broker host.

## Fix
- default broker URL to `https://broker.baudbot.ai` when `--broker-url` and `SLACK_BROKER_URL` are both unset
- keep CLI arg and existing env precedence over the default
- update command help and docs to mention the default
- add unit coverage for default resolution logic

## Tests
- `node --test bin/broker-register.test.mjs` (8/8 passing)