### PR TITLE
docs: capture broker pull-mode operational learnings in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,19 @@ sudo -u baudbot_agent ~/runtime/start.sh
 tmux new-window -n baudbot 'sudo -u baudbot_agent ~/runtime/start.sh'
 ```
 
+## Slack broker pull-mode notes
+
+- Broker delivery is now pull-based. Registration is callback-free:
+  - `sudo baudbot broker register --broker-url ... --workspace-id T... --auth-code ...`
+- After a successful broker registration, always restart to load new keys:
+  - `sudo baudbot restart`
+- The runtime starts `broker-bridge.mjs` automatically when `SLACK_BROKER_*` vars are present.
+- Quick troubleshooting when Slack replies stop:
+  - `sudo -u baudbot_agent tmux ls` (check `slack-bridge` session exists)
+  - `sudo baudbot attach --tmux slack-bridge` (bridge logs)
+  - `sudo journalctl -u baudbot.service -n 200 --no-pager` (startup/runtime errors)
+- For local/semi-integration tests that spawn `slack-bridge/broker-bridge.mjs`, keep `libsodium-wrappers-sumo` available from root install (`npm install` at repo root).
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- add a dedicated "Slack broker pull-mode notes" section to AGENTS.md
- document callback-free registration format
- document restart requirement after registration
- document runtime bridge mode selection (broker-bridge.mjs with SLACK_BROKER_* vars)
- add fast troubleshooting commands for bridge/session/service logs
- note root-level libsodium-wrappers-sumo availability needed for spawn-based integration tests

## Why
We hit a few practical gotchas while validating broker pull mode (registration, runtime bridge visibility, and test harness dependencies). This records those operational learnings for future maintainers/operators.
