### PR TITLE
docs: make dev-agent completion reporting mandatory

### DIFF
--- a/pi/skills/dev-agent/SKILL.md
+++ b/pi/skills/dev-agent/SKILL.md
@@ -196,7 +196,7 @@ gh pr view <pr-number> --json comments \
 
 ### 6. Report Completion to Baudbot
 
-Send a final report to Baudbot via `send_to_session` including:
+**You MUST send this report as soon as you're done — do not wait to be asked.** Baudbot is waiting for your report to relay results to the user. Use `send_to_session` targeting `control-agent` with:
 
 - ✅ CI status (green)
 - 📝 Review comments addressed (if any)


### PR DESCRIPTION
Dev agents weren't proactively reporting task completion back to the control agent — they completed the work but waited to be asked for status instead of sending it immediately.

This strengthens the language in step 6 of the dev-agent skill to make it unambiguous that `send_to_session` back to `control-agent` is required and immediate upon completion.

**Before:** "Send a final report to Baudbot via `send_to_session` including:"
**After:** "**You MUST send this report as soon as you're done — do not wait to be asked.** Baudbot is waiting for your report to relay results to the user. Use `send_to_session` targeting `control-agent` with:"