### PR TITLE
fix(bridge): make sendToAgent fire-and-forget to prevent leaking agent internals

### DIFF
--- a/slack-bridge/bridge.mjs
+++ b/slack-bridge/bridge.mjs
@@ -259,16 +259,6 @@ async function handleMessage(userMessage, event, say) {
 
   console.log(`💬 from <@${event.user}>: ${userMessage}`);
 
-  // React with eyes to show we're working
-  try {
-    await app.client.reactions.add({
-      token: process.env.SLACK_BOT_TOKEN,
-      channel: event.channel,
-      name: "eyes",
-      timestamp: event.ts,
-    });
-  } catch {}
-
   try {
     // Always re-resolve the socket before sending (handles agent restarts).
     // Capture into a local to avoid TOCTOU with concurrent handleMessage calls.

--- a/slack-bridge/broker-bridge.mjs
+++ b/slack-bridge/broker-bridge.mjs
@@ -453,10 +453,6 @@ async function handleUserMessage(userMessage, event) {
     logWarn(`⚠️ Suspicious patterns from <@${event.user}>: ${suspicious.join(", ")}`);
   }
 
-  try {
-    await react(event.channel, event.ts, "eyes");
-  } catch {}
-
   refreshSocket();
   const currentSocket = socketPath;
   if (!currentSocket) {

--- a/test/broker-bridge.integration.test.mjs
+++ b/test/broker-bridge.integration.test.mjs
@@ -345,6 +345,6 @@ describe("broker pull bridge semi-integration", () => {
     expect(receivedCommands.some((cmd) => cmd.type === "get_message")).toBe(false);
 
     expect(sendPayloads.some((payload) => payload.action === "chat.postMessage")).toBe(false);
-    expect(sendPayloads.some((payload) => payload.action === "reactions.add")).toBe(true);
+    expect(sendPayloads.some((payload) => payload.action === "reactions.add")).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Both `slack-bridge/bridge.mjs` and `slack-bridge/broker-bridge.mjs` had a bug where `sendToAgent()` waited for `turn_end`, called `get_message`, and returned the agent's full response. The caller then auto-posted that response to Slack via `say()`, leaking internal reasoning, tool call descriptions, and other non-user-facing text to Slack users.

The agent already replies to Slack itself via the bridge's `/send` API endpoint. The bridge should NOT also auto-post.

## Changes

### `sendToAgent()` — fire-and-forget (both files)
- Removed `subscribe` to `turn_end` event
- Removed `turn_end` handler and `get_message` call
- Now connects, sends with `mode: "steer"`, waits only for the send confirmation
- Resolves with `"delivered"` on success
- Updated JSDoc to document fire-and-forget behavior

### `broker-bridge.mjs` — `handleUserMessage()`
- Removed `say()` auto-post of agent response
- Removed `white_check_mark` reaction (agent handles its own reactions)
- Removed unused `formatForSlack` import

### `bridge.mjs` — `handleMessage()`
- Removed `formatForSlack(reply)` + `say()` auto-post
- Removed eyes→checkmark reaction swap
- Removed unused `formatForSlack` import

### `startup-cleanup.sh`
- Changed `bridge.mjs` → `broker-bridge.mjs` in tmux command
- Added `unset PKG_EXECPATH;` to prevent varlock breakage from pi's pkg-compiled binary

## Testing
- All 124 tests pass across 7 test suites ✅