### PR TITLE
security: add reflective safety-interruption guidance in tool-guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,8 +209,8 @@ The CI scripts (`bin/ci/setup-ubuntu.sh`, `bin/ci/setup-arch.sh`) run the bootst
 
 ## Security Notes
 
-- `tool-guard.ts` blocks: writes outside `/home/baudbot_agent/`, writes to source repo, writes to protected runtime files, dangerous bash patterns (reverse shells, fork bombs, rm -rf /, etc.), credential exfiltration.
-- `baudbot-safe-bash` (root-owned, `/usr/local/bin/`) is a second layer that blocks the same patterns at the shell level.
+- `tool-guard.ts` is a policy/guidance layer: it blocks many risky writes/bash patterns and provides safety-interruption reasoning, but it is not a hard sandbox boundary by itself.
+- `baudbot-safe-bash` (root-owned, `/usr/local/bin/`) is a second deny-list layer at the shell level; hard containment still comes from OS permissions and runtime hardening.
 - The firewall (`setup-firewall.sh`) restricts `baudbot_agent`'s network egress to an allowlist.
 - `/proc` is mounted with `hidepid=2` — agent can only see its own processes.
 - Secrets in `~/.config/.env` are `600` perms, never committed.

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Baudbot is built for utility **and** containment:
 - source/runtime separation with deploy manifests
 - read-only protection for security-critical files
 - session log hygiene (startup redaction + retention pruning)
-- layered tool and shell guardrails
+- layered tool and shell guardrails (policy/guidance layer, not sole containment)
 
-See [SECURITY.md](SECURITY.md) for full threat model, trust boundaries, and known risks.
+See [SECURITY.md](SECURITY.md) for full threat model, trust boundaries, and known risks. In particular: tool/shell guards are defense-in-depth policy layers; hard containment comes from OS/runtime boundaries.
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,6 @@ Slack/Email → bridge + wrapping → control-agent
 - clear trust boundaries between admin and agent runtime
 - predictable operations for deploy/update/rollback
 - support for concurrent, task-scoped coding workers
-- safer enablement of high-privilege tools via layered controls
+- safer enablement of high-privilege tools via layered controls (policy layers plus OS-level boundaries)
 
 For security controls and known risks, see [../SECURITY.md](../SECURITY.md).

--- a/docs/linux-runtime.md
+++ b/docs/linux-runtime.md
@@ -52,6 +52,7 @@ Linux-native does not mean unrestricted root access:
 
 - no general sudo for agents
 - security-critical files are read-only at runtime
+- tool/shell guards add policy + guidance (not a standalone sandbox)
 - network controls can restrict outbound traffic
 - source/runtime separation limits self-tampering blast radius
 

--- a/pi/extensions/tool-guard.ts
+++ b/pi/extensions/tool-guard.ts
@@ -1,9 +1,9 @@
 /**
  * Tool Guard Extension
  *
- * Defense-in-depth: intercepts tool calls and blocks dangerous patterns
- * before they reach the shell. Works alongside baudbot-safe-bash but catches
- * commands at the pi level, before any shell is spawned.
+ * Defense-in-depth policy and guidance layer: intercepts tool calls and blocks
+ * known-dangerous patterns before they reach the shell. This is not a full
+ * containment boundary by itself.
  *
  * Configuration (env vars):
  *   BAUDBOT_AGENT_USER   — agent Unix username (default: baudbot_agent)
@@ -13,33 +13,30 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, existsSync } from "node:fs";
 
 // ── Configuration ───────────────────────────────────────────────────────────
-// All paths are configurable via env vars so Baudbot can be deployed for any user.
-// Defaults match the standard setup (baudbot_agent user, source in admin home).
-import { existsSync } from "node:fs";
-
 const AGENT_USER = process.env.BAUDBOT_AGENT_USER || "baudbot_agent";
 const AGENT_HOME = process.env.BAUDBOT_AGENT_HOME || `/home/${AGENT_USER}`;
 const BAUDBOT_SRC_DIR = process.env.BAUDBOT_SOURCE_DIR || "";
 
 // ── Audit logging ───────────────────────────────────────────────────────────
-// Append-only log of every tool call for forensic analysis.
-// Preferred: /var/log/baudbot/commands.log (root-owned, chattr +a for tamper-proof)
-// Fallback: ~/logs/commands.log (agent-owned, not append-only but still useful)
 const AUDIT_LOG_PRIMARY = "/var/log/baudbot/commands.log";
 const AUDIT_LOG_FALLBACK = `${AGENT_HOME}/logs/commands.log`;
 const AUDIT_LOG = existsSync(AUDIT_LOG_PRIMARY)
   ? AUDIT_LOG_PRIMARY
   : AUDIT_LOG_FALLBACK;
 
+type RiskTier = "low" | "medium" | "high";
+
 function auditLog(entry: {
   tool: string;
   command?: string;
   path?: string;
   blocked: boolean;
+  warned?: boolean;
   rule?: string;
+  tier?: RiskTier;
 }) {
   try {
     const line = JSON.stringify({ ts: new Date().toISOString(), ...entry });
@@ -58,170 +55,240 @@ type DenyRule = {
   pattern: RegExp;
   label: string;
   severity: "block" | "warn";
+  tier: RiskTier;
+  rationale: string;
+  saferAlternative: string;
 };
 
+function buildSafetyReason(input: {
+  tier: RiskTier;
+  label: string;
+  ruleId: string;
+  rationale: string;
+  saferAlternative: string;
+  nextStep?: string;
+}): string {
+  const nextStep = input.nextStep || "Stop and choose a safer command. If this is truly required, ask for admin approval.";
+  return [
+    `🛡️ Safety interruption (${input.tier}-risk): ${input.label} [${input.ruleId}]`,
+    `Why risky: ${input.rationale}`,
+    `Safer option: ${input.saferAlternative}`,
+    `Next step: ${nextStep}`,
+  ].join("\n");
+}
+
 const BASH_DENY_RULES: DenyRule[] = [
-  // ── Destructive ──────────────────────────────────────────────────────
   {
     id: "rm-rf-root",
     pattern: /rm\s+(-[a-zA-Z]*[rf][a-zA-Z]*\s+){1,2}(\/\s*$|\/\*|\/\s+)/,
     label: "Recursive delete of root filesystem",
     severity: "block",
+    tier: "high",
+    rationale: "This can destroy the host filesystem and permanently break the system.",
+    saferAlternative: "Delete only a scoped workspace path under your own home directory.",
   },
   {
     id: "dd-block-device",
     pattern: /dd\s+.*of=\/dev\/(sd|vd|nvme|xvd|loop)/,
     label: "dd write to block device",
     severity: "block",
+    tier: "high",
+    rationale: "Raw writes to block devices can corrupt disks and destroy data.",
+    saferAlternative: "Write to a regular file in your workspace instead.",
   },
   {
     id: "mkfs-device",
     pattern: /mkfs\b.*\/dev\//,
     label: "mkfs on block device",
     severity: "block",
+    tier: "high",
+    rationale: "Formatting a block device erases data and can take systems offline.",
+    saferAlternative: "Use a temp file or loopback image in your workspace for tests.",
   },
-
-  // ── Remote code execution ────────────────────────────────────────────
   {
     id: "curl-pipe-sh",
     pattern: /(curl|wget)\s+[^\n|]*\|\s*(ba)?sh/,
     label: "Piping download to shell",
     severity: "block",
+    tier: "high",
+    rationale: "Executing network content directly bypasses review and can run malicious code.",
+    saferAlternative: "Download, inspect, and verify scripts before execution.",
   },
-
-  // ── Reverse shells ───────────────────────────────────────────────────
   {
     id: "revshell-bash-tcp",
     pattern: /bash\s+-i\s+>(&|\|)\s*\/dev\/tcp\//,
     label: "Reverse shell (bash /dev/tcp)",
     severity: "block",
+    tier: "high",
+    rationale: "Reverse shells are a direct remote-control/exfiltration pattern.",
+    saferAlternative: "Use approved service channels and authenticated APIs only.",
   },
   {
     id: "revshell-netcat",
     pattern: /\bnc\b.*-e\s*(\/bin\/)?(ba)?sh/,
     label: "Reverse shell (netcat)",
     severity: "block",
+    tier: "high",
+    rationale: "This creates an unauthorized remote command channel.",
+    saferAlternative: "Use project-approved communication bridges.",
   },
   {
     id: "revshell-python",
     pattern: /python[23]?\s+-c\s+.*socket.*connect.*subprocess/s,
     label: "Reverse shell (python)",
     severity: "block",
+    tier: "high",
+    rationale: "Inline reverse shells enable remote command execution.",
+    saferAlternative: "Use explicit scripts reviewed in source control.",
   },
   {
     id: "revshell-perl",
     pattern: /perl\s+-e\s+.*socket.*INET.*exec/si,
     label: "Reverse shell (perl)",
     severity: "block",
+    tier: "high",
+    rationale: "Inline reverse shells enable remote command execution.",
+    saferAlternative: "Use explicit scripts reviewed in source control.",
   },
-
-  // ── Persistence ──────────────────────────────────────────────────────
   {
     id: "crontab-modify",
     pattern: /crontab\s+-[erl]/,
     label: "Crontab modification",
     severity: "block",
+    tier: "high",
+    rationale: "Cron changes can create hidden persistence.",
+    saferAlternative: "Use managed service configuration and admin-reviewed automation.",
   },
   {
     id: "cron-write",
     pattern: />\s*\/etc\/cron/,
     label: "Write to /etc/cron",
     severity: "block",
+    tier: "high",
+    rationale: "Writing cron entries can install stealthy persistence.",
+    saferAlternative: "Use approved runtime scripts and deployment workflow.",
   },
   {
     id: "systemd-install",
     pattern: /systemctl\s+(enable|start)\s+(?!baudbot)/,
     label: "Installing/starting unknown systemd service",
     severity: "warn",
+    tier: "medium",
+    rationale: "Starting unknown services can change host behavior unexpectedly.",
+    saferAlternative: "Operate only Baudbot-related units unless explicitly approved.",
   },
-
-  // ── Privilege escalation / system file writes ────────────────────────
   {
     id: "write-auth-files",
     pattern: />\s*\/etc\/(passwd|shadow|sudoers|group)/,
     label: "Write to system auth files",
     severity: "block",
+    tier: "high",
+    rationale: "Auth file edits can create or escalate privileged access.",
+    saferAlternative: "Do not modify system auth files from agent workflows.",
   },
   {
     id: "ssh-key-injection-other",
     pattern: new RegExp(`>\\s*\\/home\\/(?!${AGENT_USER}).*\\/\\.ssh\\/authorized_keys`),
     label: "SSH key injection to another user",
     severity: "block",
+    tier: "high",
+    rationale: "Injecting SSH keys grants persistent account access.",
+    saferAlternative: "Only manage keys for the dedicated agent user via approved setup scripts.",
   },
   {
     id: "ssh-key-injection-root",
     pattern: />\s*\/root\/\.ssh\/authorized_keys/,
     label: "SSH key injection to root",
     severity: "block",
+    tier: "high",
+    rationale: "Root key injection is direct privilege escalation.",
+    saferAlternative: "Never write to root SSH authorization from agent runtime.",
   },
   {
     id: "chmod-777-sensitive",
     pattern: /chmod\s+(-[a-zA-Z]*\s+)?777\s+\/(etc|home|root|var|usr)/,
     label: "chmod 777 on sensitive path",
     severity: "block",
+    tier: "high",
+    rationale: "World-writable sensitive paths weaken host security.",
+    saferAlternative: "Use least-privilege permissions on only required files.",
   },
-
-  // ── Fork bomb ────────────────────────────────────────────────────────
   {
     id: "fork-bomb",
     pattern: /:\(\)\s*\{.*\|.*&.*\}/,
     label: "Fork bomb",
     severity: "block",
+    tier: "high",
+    rationale: "Fork bombs can exhaust system resources and cause outage.",
+    saferAlternative: "Use controlled load tests with explicit process limits.",
   },
-
-  // ── Source repo protection ─────────────────────────────────────────────
-  // Block chmod/chown on the baudbot source repo (admin-owned)
-  // Only active when BAUDBOT_SOURCE_DIR is configured
   ...(BAUDBOT_SRC_DIR ? [
     {
       id: "chmod-baudbot-source",
       pattern: new RegExp(`chmod\\b.*${escapeRegex(BAUDBOT_SRC_DIR)}`),
       label: "chmod on baudbot source repo",
       severity: "block" as const,
+      tier: "high" as const,
+      rationale: "Source permissions are admin-managed; changing them weakens separation.",
+      saferAlternative: "Request admin deploy changes from source instead.",
     },
     {
       id: "chown-baudbot-source",
       pattern: new RegExp(`chown\\b.*${escapeRegex(BAUDBOT_SRC_DIR)}`),
       label: "chown on baudbot source repo",
       severity: "block" as const,
+      tier: "high" as const,
+      rationale: "Changing source ownership breaks source/runtime trust boundaries.",
+      saferAlternative: "Keep source admin-owned and deploy via approved scripts.",
     },
     {
       id: "tee-baudbot-source",
       pattern: new RegExp(`tee\\s+.*${escapeRegex(BAUDBOT_SRC_DIR)}/`),
       label: "tee write to baudbot source repo",
       severity: "block" as const,
+      tier: "high" as const,
+      rationale: "Direct source writes bypass release controls.",
+      saferAlternative: "Edit through admin-owned workflow and redeploy.",
     },
   ] : []),
-  // Block chmod/chown on protected runtime security files
   {
     id: "chmod-runtime-security",
     pattern: /chmod\b.*\/(\.pi\/agent\/extensions\/tool-guard|runtime\/slack-bridge\/security)\./,
     label: "chmod on protected runtime security file",
     severity: "block" as const,
+    tier: "high" as const,
+    rationale: "Changing security file permissions can disable protections.",
+    saferAlternative: "Only admins may update protected files through deploy.",
   },
-
-  // ── Credential exfiltration ──────────────────────────────────────────
   {
     id: "env-exfil-curl",
     pattern: /\benv\b.*\|\s*(curl|wget|nc)\b/,
     label: "Piping environment to network tool",
     severity: "block",
+    tier: "high",
+    rationale: "Environment data often contains credentials and secrets.",
+    saferAlternative: "Inspect needed variables locally without transmitting them.",
   },
   {
     id: "cat-env-curl",
     pattern: /cat\s+.*\.env.*\|\s*(curl|wget|nc)\b/,
     label: "Exfiltrating .env via network",
     severity: "block",
+    tier: "high",
+    rationale: ".env files commonly contain API keys and secrets.",
+    saferAlternative: "Never transmit .env contents; use secret managers.",
   },
   {
     id: "base64-exfil",
     pattern: /base64\s+.*\|\s*(curl|wget)\b/,
     label: "Base64-encoding data for exfiltration",
     severity: "block",
+    tier: "high",
+    rationale: "Base64 + network transfer is a common data exfiltration pattern.",
+    saferAlternative: "Keep sensitive data local and minimized.",
   },
 ];
 
-// Paths that should never be written to
 const SENSITIVE_WRITE_PATHS = [
   />\s*\/etc\//,
   />\s*\/root\//,
@@ -230,25 +297,17 @@ const SENSITIVE_WRITE_PATHS = [
   />\s*\/sys\//,
 ];
 
-// Paths that should never be deleted
 const SENSITIVE_DELETE_PATHS = [
   /rm\s+(-[a-zA-Z]*\s+)*\/(etc|boot|root|usr|var|proc|sys)\b/,
   new RegExp(`rm\\s+(-[a-zA-Z]*\\s+)*\\/home\\/(?!${AGENT_USER})`),
 ];
 
-// ── Workspace confinement ───────────────────────────────────────────────────
-// ALLOW LIST: write/edit tools are confined to these prefixes.
-// Everything else is blocked. This replaces the old deny-list approach.
 const ALLOWED_WRITE_PREFIXES = [AGENT_HOME + "/"];
 
 function isAllowedWritePath(filePath: string): boolean {
   return ALLOWED_WRITE_PREFIXES.some((p) => filePath.startsWith(p));
 }
 
-// ── Read-only source repo ───────────────────────────────────────────────────
-// ── Protected runtime paths ─────────────────────────────────────────────────
-// Security-critical files deployed to the agent's runtime directories.
-// These are copies from the source repo that the agent must not modify.
 const PROTECTED_RUNTIME_FILES = [
   `${AGENT_HOME}/.pi/agent/extensions/tool-guard.ts`,
   `${AGENT_HOME}/.pi/agent/extensions/tool-guard.test.mjs`,
@@ -257,11 +316,9 @@ const PROTECTED_RUNTIME_FILES = [
 ];
 
 function isProtectedPath(filePath: string): boolean {
-  // Entire source repo is read-only (when configured)
   if (BAUDBOT_SRC_DIR && (filePath.startsWith(BAUDBOT_SRC_DIR + "/") || filePath === BAUDBOT_SRC_DIR)) {
     return true;
   }
-  // Protected runtime security files
   for (const file of PROTECTED_RUNTIME_FILES) {
     if (filePath === file) return true;
   }
@@ -270,18 +327,15 @@ function isProtectedPath(filePath: string): boolean {
 
 export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, _ctx) => {
-    // Guard bash/Bash tool calls
     if (isToolCallEventType("bash", event)) {
       const command = event.input.command ?? "";
 
-      // Audit log (before any deny checks, so we log blocked commands too)
       auditLog({
         tool: "bash",
         command: command.slice(0, 2000),
         blocked: false,
       });
 
-      // Check deny rules
       for (const rule of BASH_DENY_RULES) {
         if (rule.pattern.test(command)) {
           if (rule.severity === "block") {
@@ -289,24 +343,39 @@ export default function (pi: ExtensionAPI) {
               tool: "bash",
               command: command.slice(0, 2000),
               blocked: true,
+              warned: false,
               rule: rule.id,
+              tier: rule.tier,
             });
             console.error(
               `🛡️ TOOL-GUARD BLOCKED [${rule.id}]: ${rule.label}\n   Command: ${command.slice(0, 200)}`,
             );
             return {
               block: true,
-              reason: `🛡️ Blocked by tool-guard: ${rule.label} (${rule.id}). This command pattern is not allowed.`,
+              reason: buildSafetyReason({
+                tier: rule.tier,
+                label: rule.label,
+                ruleId: rule.id,
+                rationale: rule.rationale,
+                saferAlternative: rule.saferAlternative,
+              }),
             };
           }
-          // Warn but allow (for severity: "warn")
+
+          auditLog({
+            tool: "bash",
+            command: command.slice(0, 2000),
+            blocked: false,
+            warned: true,
+            rule: rule.id,
+            tier: rule.tier,
+          });
           console.warn(
-            `🛡️ TOOL-GUARD WARNING [${rule.id}]: ${rule.label}\n   Command: ${command.slice(0, 200)}`,
+            `🛡️ TOOL-GUARD CAUTION [${rule.id}] (${rule.tier}): ${rule.label}\n   Command: ${command.slice(0, 200)}\n   Why risky: ${rule.rationale}\n   Safer option: ${rule.saferAlternative}`,
           );
         }
       }
 
-      // Check sensitive write paths
       for (const pattern of SENSITIVE_WRITE_PATHS) {
         if (pattern.test(command)) {
           auditLog({
@@ -314,19 +383,24 @@ export default function (pi: ExtensionAPI) {
             command: command.slice(0, 2000),
             blocked: true,
             rule: "sensitive-write",
+            tier: "high",
           });
           console.error(
             `🛡️ TOOL-GUARD BLOCKED [sensitive-write]: Write to sensitive path\n   Command: ${command.slice(0, 200)}`,
           );
           return {
             block: true,
-            reason:
-              "🛡️ Blocked by tool-guard: Write to sensitive system path. This operation is not allowed.",
+            reason: buildSafetyReason({
+              tier: "high",
+              label: "Write to sensitive system path",
+              ruleId: "sensitive-write",
+              rationale: "Direct writes to core system paths can compromise host integrity.",
+              saferAlternative: "Write only inside approved agent-owned workspace paths.",
+            }),
           };
         }
       }
 
-      // Check sensitive delete paths
       for (const pattern of SENSITIVE_DELETE_PATHS) {
         if (pattern.test(command)) {
           auditLog({
@@ -334,43 +408,50 @@ export default function (pi: ExtensionAPI) {
             command: command.slice(0, 2000),
             blocked: true,
             rule: "sensitive-delete",
+            tier: "high",
           });
           console.error(
             `🛡️ TOOL-GUARD BLOCKED [sensitive-delete]: Delete of sensitive path\n   Command: ${command.slice(0, 200)}`,
           );
           return {
             block: true,
-            reason:
-              "🛡️ Blocked by tool-guard: Delete of sensitive system path. This operation is not allowed.",
+            reason: buildSafetyReason({
+              tier: "high",
+              label: "Delete of sensitive system path",
+              ruleId: "sensitive-delete",
+              rationale: "Deleting system directories can cause outage or data loss.",
+              saferAlternative: "Delete only scoped files under your own workspace.",
+            }),
           };
         }
       }
     }
 
-    // Guard write tool — workspace confinement + protected baudbot files
     if (isToolCallEventType("write", event)) {
       const filePath = (event.input as { path?: string }).path ?? "";
-
-      // Audit log
       auditLog({ tool: "write", path: filePath, blocked: false });
 
-      // ALLOW LIST: only permit writes under baudbot_agent's home
       if (!isAllowedWritePath(filePath)) {
         auditLog({
           tool: "write",
           path: filePath,
           blocked: true,
           rule: "workspace-confinement",
+          tier: "high",
         });
-        console.error(
-          `🛡️ TOOL-GUARD BLOCKED [workspace-confinement]: ${filePath}`,
-        );
+        console.error(`🛡️ TOOL-GUARD BLOCKED [workspace-confinement]: ${filePath}`);
         return {
           block: true,
-          reason: `🛡️ Blocked by tool-guard: Cannot write to ${filePath}. Only ${AGENT_HOME}/ is allowed.`,
+          reason: buildSafetyReason({
+            tier: "high",
+            label: "Write outside agent-owned workspace",
+            ruleId: "workspace-confinement",
+            rationale: "Writing outside the allowed workspace violates runtime boundaries.",
+            saferAlternative: `Write only under ${AGENT_HOME}/`,
+          }),
         };
       }
-      // Block writes to read-only source repo and protected runtime files
+
       if (isProtectedPath(filePath)) {
         const rule = BAUDBOT_SRC_DIR && filePath.startsWith(BAUDBOT_SRC_DIR)
           ? "readonly-source"
@@ -380,42 +461,50 @@ export default function (pi: ExtensionAPI) {
           path: filePath,
           blocked: true,
           rule,
+          tier: "high",
         });
         const desc = BAUDBOT_SRC_DIR && filePath.startsWith(BAUDBOT_SRC_DIR)
-          ? `${filePath} is in the read-only source repo ~/baudbot/. Edit source and run deploy.sh instead.`
-          : `${filePath} is a protected security file. Only the admin can modify it via deploy.sh.`;
+          ? "Source repo paths are admin-managed and read-only to the agent workflow."
+          : "This runtime file is security-critical and admin-managed.";
         console.error(`🛡️ TOOL-GUARD BLOCKED [${rule}]: ${filePath}`);
         return {
           block: true,
-          reason: `🛡️ Blocked by tool-guard: ${desc}`,
+          reason: buildSafetyReason({
+            tier: "high",
+            label: "Write to protected path",
+            ruleId: rule,
+            rationale: desc,
+            saferAlternative: "Edit in approved source workflow and deploy via admin controls.",
+          }),
         };
       }
     }
 
-    // Guard edit tool — same workspace confinement + protected paths
     if (isToolCallEventType("edit", event)) {
       const filePath = (event.input as { path?: string }).path ?? "";
-
-      // Audit log
       auditLog({ tool: "edit", path: filePath, blocked: false });
 
-      // ALLOW LIST: only permit edits under baudbot_agent's home
       if (!isAllowedWritePath(filePath)) {
         auditLog({
           tool: "edit",
           path: filePath,
           blocked: true,
           rule: "workspace-confinement",
+          tier: "high",
         });
-        console.error(
-          `🛡️ TOOL-GUARD BLOCKED [workspace-confinement]: ${filePath}`,
-        );
+        console.error(`🛡️ TOOL-GUARD BLOCKED [workspace-confinement]: ${filePath}`);
         return {
           block: true,
-          reason: `🛡️ Blocked by tool-guard: Cannot edit ${filePath}. Only ${AGENT_HOME}/ is allowed.`,
+          reason: buildSafetyReason({
+            tier: "high",
+            label: "Edit outside agent-owned workspace",
+            ruleId: "workspace-confinement",
+            rationale: "Editing outside the allowed workspace violates runtime boundaries.",
+            saferAlternative: `Edit only under ${AGENT_HOME}/`,
+          }),
         };
       }
-      // Block edits to read-only source repo and protected runtime files
+
       if (isProtectedPath(filePath)) {
         const rule = BAUDBOT_SRC_DIR && filePath.startsWith(BAUDBOT_SRC_DIR)
           ? "readonly-source"
@@ -425,14 +514,21 @@ export default function (pi: ExtensionAPI) {
           path: filePath,
           blocked: true,
           rule,
+          tier: "high",
         });
         const desc = BAUDBOT_SRC_DIR && filePath.startsWith(BAUDBOT_SRC_DIR)
-          ? `${filePath} is in the read-only source repo ~/baudbot/. Edit source and run deploy.sh instead.`
-          : `${filePath} is a protected security file. Only the admin can modify it via deploy.sh.`;
+          ? "Source repo paths are admin-managed and read-only to the agent workflow."
+          : "This runtime file is security-critical and admin-managed.";
         console.error(`🛡️ TOOL-GUARD BLOCKED [${rule}]: ${filePath}`);
         return {
           block: true,
-          reason: `🛡️ Blocked by tool-guard: ${desc}`,
+          reason: buildSafetyReason({
+            tier: "high",
+            label: "Edit to protected path",
+            ruleId: rule,
+            rationale: desc,
+            saferAlternative: "Edit in approved source workflow and deploy via admin controls.",
+          }),
         };
       }
     }


### PR DESCRIPTION
## Summary
- add structured safety-interruption reasoning for blocked high-risk tool-guard actions
- enrich deny rules with risk metadata (`tier`, `rationale`, `saferAlternative`)
- keep low-interruption defaults (warn rules stay non-blocking; high-risk rules block)
- enrich audit entries with warning/risk-tier context
- update docs to avoid overstating tool-guard as a hard containment boundary

## Validation
- node --test pi/extensions/tool-guard.test.mjs
- npm run test:js

## Notes
- This PR treats tool-guard as a policy/guidance layer in defense-in-depth.
- Hard containment remains OS/runtime controls (permissions, read-only paths, service hardening, firewall, isolation).
