### PR TITLE
deploy: replace manual bridge restart hint with baudbot restart

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -448,6 +448,6 @@ if [ "$DRY_RUN" -eq 1 ]; then
 else
   echo "✅ Deployed $GIT_SHA_SHORT. Protected files are read-only."
   echo ""
-  echo "If the bridge is running, restart it:"
-  echo "  sudo -u baudbot_agent bash -c 'cd ~/runtime/slack-bridge && node bridge.mjs'"
+  echo "Restart runtime services to load changes (recommended):"
+  echo "  sudo baudbot restart"
 fi


### PR DESCRIPTION
## Summary
- remove the manual node bridge.mjs restart hint from deploy output
- replace with the managed restart command: sudo baudbot restart

## Why
- avoids suggesting a direct bridge invocation that can bypass managed runtime behavior
- matches current start/restart flow where launcher selects the correct bridge mode

## Validation
- bash -n bin/deploy.sh