### PR TITLE
bridge: require registration token for broker registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ sudo baudbot update
 sudo baudbot rollback previous
 
 # Register a server with Slack broker (after OAuth callback)
-sudo baudbot broker register --broker-url https://broker.example.com --workspace-id T0123ABCD --auth-code <code>
+sudo baudbot broker register --broker-url https://broker.example.com --workspace-id T0123ABCD --registration-token <token>
 
 # Rotate an API key after setup (prompts hidden input)
 sudo baudbot env set ANTHROPIC_API_KEY --restart
@@ -146,7 +146,7 @@ tmux new-window -n baudbot 'sudo -u baudbot_agent ~/runtime/start.sh'
 ## Slack broker pull-mode notes
 
 - Broker delivery is now pull-based. Registration is callback-free:
-  - `sudo baudbot broker register --broker-url ... --workspace-id T... --auth-code ...`
+  - `sudo baudbot broker register --broker-url ... --workspace-id T... --registration-token ...`
 - After a successful broker registration, always restart to load new keys:
   - `sudo baudbot restart`
 - The runtime starts `broker-bridge.mjs` automatically when `SLACK_BROKER_*` vars are present.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -49,7 +49,7 @@ If you're using the Slack broker OAuth flow, register this server after install:
 sudo baudbot broker register \
   --broker-url https://your-broker.example.com \
   --workspace-id T0123ABCD \
-  --auth-code <auth-code-from-oauth-callback>
+  --registration-token <token-from-dashboard-callback>
 ```
 
 `baudbot setup` is host provisioning only; do not use `baudbot setup --slack-broker`.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Slack broker registration (after OAuth callback). When `SLACK_BROKER_*` variable
 sudo baudbot broker register \
   --broker-url https://your-broker.example.com \
   --workspace-id T0123ABCD \
-  --auth-code <auth-code-from-oauth-callback>
+  --registration-token <token-from-dashboard-callback>
 ```
 
 Need to rotate/update a key later?

--- a/bin/baudbot
+++ b/bin/baudbot
@@ -421,11 +421,11 @@ case "${1:-}" in
         exec "$NODE_BIN" "$BAUDBOT_ROOT/bin/broker-register.mjs" "$@"
         ;;
       --help|-h|"")
-        echo "Usage: sudo baudbot broker register [--broker-url URL] [--workspace-id ID] [--auth-code CODE] [-v|--verbose]"
+        echo "Usage: sudo baudbot broker register [--broker-url URL] [--workspace-id ID] --registration-token TOKEN [-v|--verbose]"
         ;;
       *)
         echo "Unknown broker subcommand: ${1:-}"
-        echo "Usage: sudo baudbot broker register [--broker-url URL] [--workspace-id ID] [--auth-code CODE] [-v|--verbose]"
+        echo "Usage: sudo baudbot broker register [--broker-url URL] [--workspace-id ID] --registration-token TOKEN [-v|--verbose]"
         exit 1
         ;;
     esac

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,7 +63,7 @@ sudo baudbot env sync --restart
 sudo baudbot broker register \
   --broker-url https://your-broker.example.com \
   --workspace-id T0123ABCD \
-  --auth-code <auth-code-from-oauth-callback>
+  --registration-token <token-from-dashboard-callback>
 ```
 
 Do not use `baudbot setup --slack-broker` — `setup` is host provisioning only.


### PR DESCRIPTION
## Summary
- require `--registration-token` for `baudbot broker register`
- remove legacy `--auth-code` parsing and payload support from `bin/broker-register.mjs`
- update broker registration usage/help text in `bin/baudbot`
- update docs/examples to use token-only registration flow:
  - `README.md`
  - `CONFIGURATION.md`
  - `AGENTS.md`
  - `docs/operations.md`
- update broker registration tests for token-only behavior

## Why
`modem-dev/baudbot-services` merged the dashboard-canonical registration flow and `/api/register` now requires `registration_token` in the primary path. Keeping `auth_code` in baudbot caused stale UX/docs and a misleading CLI contract.

## Testing
- `node --test bin/broker-register.test.mjs`
- `node --check bin/broker-register.mjs`
- `bash -n bin/baudbot`
