### PR TITLE
docs: add directory-specific AGENTS.md files and improve root guidelines

### DIFF
--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,0 +1,50 @@
+# bin/ — Agent Guidelines
+
+Scope: shell CLI and operational scripts under `bin/`.
+
+## Focus areas
+
+- CLI entrypoint (`baudbot`) and runtime helpers
+- deploy/update/rollback flows
+- security audit and firewall scripts
+- install/uninstall operational scripts
+- CI infrastructure (`bin/ci/`)
+- JS tooling: `broker-register.mjs`, `scan-extensions.mjs` (and their tests)
+- systemd unit files: `baudbot.service`, `baudbot-firewall.service`
+
+## Rules
+
+- Keep CLIs thin; move reusable logic into `bin/lib/*.sh`.
+- Reuse shared helpers (`shell-common.sh`, `paths-common.sh`, `release-common.sh`, etc.) instead of duplicating constants or logging/error patterns.
+- Prefer portable shell patterns; distro-specific branches are acceptable when reliability improves.
+- Any security-relevant shell change must include/adjust tests.
+
+## Critical files
+
+Treat as security-critical:
+- `baudbot-safe-bash` — runtime command-blocking wrapper
+- `harden-permissions.sh` — filesystem permission lockdown
+- `setup-firewall.sh` — network egress lockdown
+- `security-audit.sh` — security posture audit
+- `scan-extensions.mjs` — static analysis scanner for extensions
+- `redact-logs.sh` — secret redaction from session logs
+
+## Notes
+
+- Shared helpers in `bin/lib/` have co-located test files (e.g. `deploy-common.test.sh`, `json-common.test.sh`). Update tests when changing helpers.
+- For JS files in `bin/`, also run `npm run lint:js` and `npm run test:js`.
+
+## Validation
+
+Run before finishing shell work:
+
+```bash
+npm run lint:shell
+npm run test:shell
+```
+
+For security-sensitive updates, also run:
+
+```bash
+bin/security-audit.sh --deep
+```

--- a/pi/extensions/AGENTS.md
+++ b/pi/extensions/AGENTS.md
@@ -1,0 +1,36 @@
+# pi/extensions/ — Agent Guidelines
+
+Scope: extension code under `pi/extensions/`.
+
+## Focus areas
+
+- Tool extensions and runtime behaviors
+- Session-control and orchestration helpers
+- Safety/policy logic and stateful agent features
+
+## Rules
+
+- Keep extension behavior deterministic and testable.
+- Avoid module-scope side effects for security-sensitive code.
+- Preserve compatibility with deployed runtime assumptions (`~/.pi/agent/...`).
+- If changing extension behavior, update related skill/docs references where relevant.
+
+## Subdirectory extensions
+
+Some extensions have their own package scope:
+- `kernel/` — on-kernel cloud browser execution (has own `package.json`)
+- `agentmail/` — email integration (has own `package.json`)
+- `email-monitor/` — email monitoring
+
+## Critical files
+
+Treat these as security-critical and require strong justification + tests:
+- `tool-guard.ts`
+- `tool-guard.test.mjs`
+
+## Validation
+
+```bash
+npm run lint:js
+npm run test:js
+```

--- a/slack-bridge/AGENTS.md
+++ b/slack-bridge/AGENTS.md
@@ -1,0 +1,37 @@
+# slack-bridge/ — Agent Guidelines
+
+Scope: Slack bridge runtime and security modules under `slack-bridge/`.
+
+## Focus areas
+
+- inbound/outbound message handling
+- broker pull-mode bridge behavior
+- auth/rate-limit/content-security controls
+
+## Rules
+
+- Security behavior changes must be explicit, minimal, and test-backed.
+- Do not reduce authentication, validation, or rate-limiting protections without clear rationale.
+- Keep operational logging useful but avoid leaking sensitive values.
+
+## Key files
+
+- `broker-bridge.mjs` — main broker pull-mode bridge runtime (preferred)
+- `bridge.mjs` — legacy Socket Mode bridge
+- `security.mjs` — auth, rate-limiting, content security
+- `crypto.mjs` — cryptographic canonicalization for broker signing
+
+## Critical files
+
+Treat as security-critical:
+- `security.mjs`
+- `security.test.mjs`
+- `crypto.mjs`
+- `crypto.test.mjs`
+
+## Validation
+
+```bash
+npm run lint:js
+npm test
+```


### PR DESCRIPTION
## Summary

- **Root `AGENTS.md`**: Added "How Baudbot works" architecture overview with data flow diagram and deployment model. Expanded directory listing to cover `pi/skills/`, `test/`, `hooks/`, `.github/`, `.env.schema`, and `bootstrap.sh`. Replaced vague guardrails with explicit hard constraints (pre-commit hook, CI) vs strong defaults. Removed redundant "Architecture model" section. Trimmed explanations the agent already knows.
- **`bin/AGENTS.md`** (new): Focus areas, rules, security-critical file list, co-located test notes, validation commands.
- **`pi/extensions/AGENTS.md`** (new): Focus areas, rules, subdirectory extensions (`kernel/`, `agentmail/`, `email-monitor/`), critical files, validation commands.
- **`slack-bridge/AGENTS.md`** (new): Focus areas, rules, key files inventory, security-critical files (added `crypto.mjs`/`crypto.test.mjs`), validation commands.