### PR TITLE
cli: restart bridge tmux session before systemd restart

### DIFF
--- a/bin/baudbot
+++ b/bin/baudbot
@@ -351,6 +351,16 @@ case "${1:-}" in
     shift
     require_root "restart"
     if has_systemd; then
+      # Ensure any pre-existing detached bridge tmux session is torn down so
+      # restart always boots a fresh bridge from currently deployed runtime files.
+      AGENT_USER="${BAUDBOT_AGENT_USER:-baudbot_agent}"
+      if command -v tmux >/dev/null 2>&1; then
+        if command -v sudo >/dev/null 2>&1; then
+          sudo -u "$AGENT_USER" tmux kill-session -t slack-bridge 2>/dev/null || true
+        elif command -v runuser >/dev/null 2>&1; then
+          runuser -u "$AGENT_USER" -- tmux kill-session -t slack-bridge 2>/dev/null || true
+        fi
+      fi
       exec systemctl restart baudbot "$@"
     else
       echo "systemd not available."


### PR DESCRIPTION
## Summary
- update `baudbot restart` to explicitly kill the `slack-bridge` tmux session before restarting the systemd service
- this ensures a detached/stale bridge process cannot survive and continue running old behavior after restart
- keep behavior best-effort and distro-safe:
  - use `sudo -u <agent>` when available
  - fallback to `runuser -u <agent>` when `sudo` is unavailable

## Tests
- add `bin/baudbot.test.sh` coverage asserting restart path:
  - kills tmux session `slack-bridge`
  - then calls `systemctl restart baudbot`
- ran: `bash bin/baudbot.test.sh`
- ran: `bash -n bin/baudbot`
