### PR TITLE
deploy: fix rollback release-root path contamination

### DIFF
--- a/bin/rollback-release.sh
+++ b/bin/rollback-release.sh
@@ -46,7 +46,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --release-root)
       [ "$#" -ge 2 ] || die "--release-root requires a value"
-      bb_refresh_release_paths "$2" 1
+      BAUDBOT_RELEASE_ROOT="$2"
       shift 2
       ;;
     --skip-restart)
@@ -62,6 +62,10 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+# Normalize release paths after env + CLI parsing so BAUDBOT_RELEASE_ROOT always
+# wins over any inherited BAUDBOT_CURRENT/PREVIOUS/RELEASES path variables.
+bb_refresh_release_paths "${BAUDBOT_RELEASE_ROOT:-/opt/baudbot}" 1
 
 bb_require_root "rollback (or BAUDBOT_ROLLBACK_ALLOW_NON_ROOT=1 for tests)" "$BAUDBOT_ROLLBACK_ALLOW_NON_ROOT"
 


### PR DESCRIPTION
## Summary
- fix `bin/rollback-release.sh` to normalize release paths after env/CLI parsing
- ensure `BAUDBOT_RELEASE_ROOT` wins over inherited `BAUDBOT_RELEASES_DIR`, `BAUDBOT_CURRENT_LINK`, and `BAUDBOT_PREVIOUS_LINK`
- add regression coverage in `bin/rollback-release.test.sh` for stale rollback path env vars

## Validation
- `bin/rollback-release.test.sh`
- `bin/update-release.test.sh`
- `npm run test:shell`
