### PR TITLE
bridge: naming-clarity refactor for broker/webhook payloads

### DIFF
--- a/slack-bridge/security.mjs
+++ b/slack-bridge/security.mjs
@@ -206,17 +206,17 @@ export function formatForSlack(text) {
 /**
  * Validate params for POST /send. Returns error string or null if valid.
  */
-export function validateSendParams(params) {
-  if (typeof params.channel !== "string" || !params.channel.startsWith("C")) {
+export function validateSendParams(sendRequestBody) {
+  if (typeof sendRequestBody.channel !== "string" || !sendRequestBody.channel.startsWith("C")) {
     return "channel must be a string starting with C";
   }
-  if (typeof params.text !== "string" || params.text.length === 0) {
+  if (typeof sendRequestBody.text !== "string" || sendRequestBody.text.length === 0) {
     return "text must be a non-empty string";
   }
-  if (params.text.length > 4000) {
+  if (sendRequestBody.text.length > 4000) {
     return "text too long (max 4000)";
   }
-  if (params.thread_ts !== undefined && typeof params.thread_ts !== "string") {
+  if (sendRequestBody.thread_ts !== undefined && typeof sendRequestBody.thread_ts !== "string") {
     return "thread_ts must be a string";
   }
   return null;
@@ -225,14 +225,14 @@ export function validateSendParams(params) {
 /**
  * Validate params for POST /react. Returns error string or null if valid.
  */
-export function validateReactParams(params) {
-  if (typeof params.channel !== "string") {
+export function validateReactParams(reactRequestBody) {
+  if (typeof reactRequestBody.channel !== "string") {
     return "channel must be a string";
   }
-  if (typeof params.timestamp !== "string" || !/^\d+\.\d+$/.test(params.timestamp)) {
+  if (typeof reactRequestBody.timestamp !== "string" || !/^\d+\.\d+$/.test(reactRequestBody.timestamp)) {
     return "timestamp must be a string matching digits.digits";
   }
-  if (typeof params.emoji !== "string" || !/^[a-z0-9_+-]+$/.test(params.emoji)) {
+  if (typeof reactRequestBody.emoji !== "string" || !/^[a-z0-9_+-]+$/.test(reactRequestBody.emoji)) {
     return "emoji must be a valid emoji name (lowercase alphanumeric, _, +, -)";
   }
   return null;


### PR DESCRIPTION
## Summary
Naming-clarity-only refactor to make request/response/payload variable names explicit by domain/context across Slack bridge and broker registration code.

## Before -> After highlights
- payload -> registerRequestBody, brokerResponseBody, slackEventEnvelopePayload
- body -> brokerRequestBody, rawApiRequestBody, apiRequestBody, brokerPubkeyResponseBody, registerResponseBody
- response -> brokerHttpResponse, brokerPubkeyResponse, registerResponse
- params -> sendRequestBody / reactRequestBody / slackApiRequestBody
- sendViaBroker input body -> actionRequestBody
- signProtocolRequest input payload -> protocolRequestPayload

## Scope
- bin/broker-register.mjs
- slack-bridge/broker-bridge.mjs
- slack-bridge/bridge.mjs
- slack-bridge/security.mjs

## Validation
- npm run typecheck
- npm test
- npm run lint:js

## Behavior
No business logic, endpoint behavior, DB/schema behavior, or API contract changes. This PR is naming/refactor-only.