### PR TITLE
docs: add explicit naming guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ sudo baudbot rollback previous
 **Strong defaults:**
 - When behavior changes, update docs in the same PR (`README.md`, `docs/*`, `CONFIGURATION.md`, and relevant `AGENTS.md` files).
 - Prefer distro-agnostic shell; distro-specific branches are acceptable when reliability improves.
+- Prefer explicit, domain-aware naming for shared code (`FooRequestBody`, `SlackWorkspaceKVRecord`, `BrokerHttpResponse`, etc.).
+- Keep action names semantic (`activateWorkspace`), and use storage/runtime qualifiers on read/write helpers when helpful (`getWorkspaceKVRecord`, `putWorkspaceDBRow`).
+- Local variables may be lighter-weight when scope is short and context is obvious, but avoid ambiguous names (`data`, `payload`, `body`, `response`) when crossing boundaries.
 
 ## Tests and quality gates
 


### PR DESCRIPTION
## Summary
Add repo-wide agent guidance for naming clarity in code.

## Changes
- Prefer explicit, domain-aware names for shared code.
- Keep action names semantic.
- Use storage/runtime qualifiers for read/write helpers when useful.
- Allow lighter local variable names only when scope is short and context is obvious.

## Scope
- AGENTS.md only

## Behavior
Documentation-only change; no runtime logic changes.