### PR TITLE
ci: use Blacksmith runners in CI and integration workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: &default-runner blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +26,7 @@ jobs:
         run: npm run typecheck
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: *default-runner
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
         run: npm run test:coverage
 
   secret-scan:
-    runs-on: ubuntu-latest
+    runs-on: *default-runner
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   docs-scope:
-    runs-on: ubuntu-latest
+    runs-on: &default-runner blacksmith-4vcpu-ubuntu-2404
     outputs:
       docs_only: ${{ steps.check.outputs.docs_only }}
     steps:
@@ -58,7 +58,7 @@ jobs:
   integration:
     needs: [docs-scope]
     if: needs.docs-scope.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: *default-runner
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- switch CI workflow jobs from `ubuntu-latest` to the Blacksmith runner class used in modem
- switch integration workflow jobs to the same runner class
- use a per-workflow YAML anchor (`&default-runner`) to avoid repeating the runner label

## Testing
- workflow-only change (no local runtime tests)
