### PR TITLE
fix: unset PKG_EXECPATH and stale broker token vars in startup-cleanup

### DIFF
--- a/pi/skills/control-agent/startup-cleanup.sh
+++ b/pi/skills/control-agent/startup-cleanup.sh
@@ -11,6 +11,11 @@
 
 set -euo pipefail
 
+# Prevent varlock SEA binary from misinterpreting argv when called from a
+# session that was itself launched via varlock (PKG_EXECPATH leaks into child
+# processes and causes `varlock run` to treat subcommands as Node module paths).
+unset PKG_EXECPATH 2>/dev/null || true
+
 BRIDGE_POLICY_HELPER="$HOME/runtime/bin/lib/bridge-restart-policy.sh"
 if [ -r "$BRIDGE_POLICY_HELPER" ]; then
   # shellcheck source=bin/lib/bridge-restart-policy.sh
@@ -140,6 +145,16 @@ echo "Starting slack-bridge ($BRIDGE_SCRIPT) with PI_SESSION_ID=$MY_UUID..."
 mkdir -p "$BRIDGE_LOG_DIR"
 (
   unset PKG_EXECPATH
+  # Clear ALL varlock-managed env vars inherited from the parent session.
+  # varlock run does not override vars already set in the environment, so
+  # stale values (e.g. expired broker tokens) would leak through. By unsetting
+  # every key varlock manages, we guarantee varlock run injects fresh values
+  # from ~/.config/.env on every bridge restart.
+  if command -v varlock >/dev/null 2>&1; then
+    while IFS='=' read -r key _; do
+      [ -n "$key" ] && unset "$key"
+    done < <(varlock load --path "$HOME/.config/" --format env --compact 2>/dev/null)
+  fi
   export PATH="$HOME/.varlock/bin:$HOME/opt/node/bin:$PATH"
   export PI_SESSION_ID="$MY_UUID"
   cd /opt/baudbot/current/slack-bridge


### PR DESCRIPTION
## Problem

PR #148 introduced `bridge-restart-policy.sh` sourcing and made `startup-cleanup.sh` the canonical mid-session bridge restart path. Two classes of inherited env vars cause bridge startup failures when the script is called from a running control-agent session:

### Bug 1: `PKG_EXECPATH` poisons varlock probes

The pi agent process inherits `PKG_EXECPATH` from its initial varlock launch. This causes varlock's SEA binary to misinterpret `argv` — treating subcommands like `run` as Node module paths:

```
Error: Cannot find module '/home/baudbot_agent/run'
```

The varlock broker-key probes on lines 115-122 fail silently (`2>/dev/null`), so `BRIDGE_SCRIPT` stays empty → "No Slack transport configured" → **bridge never starts**.

### Bug 2: Stale env vars bypass varlock injection

`varlock run` does **not** override env vars already set in the parent process. This affects _every_ varlock-managed variable, not just broker tokens. If any value is rotated after session start (broker token refresh, API key rotation, config change), the supervisor passes the stale inherited values instead of reading fresh ones from `~/.config/.env`.

The original fix hardcoded `unset` for just `SLACK_BROKER_ACCESS_TOKEN` and `SLACK_BROKER_ACCESS_TOKEN_EXPIRES_AT`, but that's a whack-a-mole approach — any new rotatable credential would need another hardcoded `unset` line.

## Fix

1. **`unset PKG_EXECPATH`** at the **top** of the script (line 14, before varlock probes)
2. **Dynamic unset of ALL varlock-managed keys** in the supervisor subshell — uses `varlock load --format env --compact` to enumerate every key varlock manages, then unsets them all before `varlock run` injects fresh values:

```bash
if command -v varlock >/dev/null 2>&1; then
  while IFS='=' read -r key _; do
    [ -n "$key" ] && unset "$key"
  done < <(varlock load --path "$HOME/.config/" --format env --compact 2>/dev/null)
fi
```

This guarantees every bridge restart gets fresh values from `~/.config/.env`, regardless of which keys changed.

## Testing

- All 15 existing tests pass (`bin/test.sh`)
- Verified manually: bridge starts correctly when called from a session with `PKG_EXECPATH` set and stale `SLACK_BROKER_ACCESS_TOKEN_EXPIRES_AT`

Regression from #148.