### PR TITLE
fix: improve bridge message when agent socket is not found

### DIFF
--- a/slack-bridge/broker-bridge.mjs
+++ b/slack-bridge/broker-bridge.mjs
@@ -699,7 +699,7 @@ async function handleUserMessage(userMessage, event) {
   const currentSocket = socketPath;
   if (!currentSocket) {
     logError("🔌 no pi socket found — agent may not be running");
-    await say(event.channel, "⏳ Agent is starting up — try again in a moment.", event.ts);
+    await say(event.channel, "🔌 Agent is not connected — it may be restarting or the session expired. Run `sudo baudbot restart` to bring it back.", event.ts);
     return true;
   }
   logInfo(`🔌 forwarding to agent via ${currentSocket}`);


### PR DESCRIPTION
## Problem

When the bridge can't find the agent's pi socket, it tells the user "Agent is starting up — try again in a moment." This is misleading — the usual cause is a stale session UUID or a crashed agent, not a slow startup.

## Fix

Replace with a more accurate and actionable message:

> 🔌 Agent is not connected — it may be restarting or the session expired. Run `sudo baudbot restart` to bring it back.

## Testing

All 15 test suites pass (`bin/test.sh`).