### PR TITLE
ci: automate semver releases on main using Sonnet

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -67,10 +67,11 @@ jobs:
 
           gh api \
             --paginate \
+            --slurp \
             "/repos/$OWNER/$REPO/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100" \
             > /tmp/all_prs.json
 
-          jq --arg start "$START_DATE" '[.[] | select(.merged_at != null and .merged_at > $start)] | sort_by(.merged_at)' /tmp/all_prs.json > /tmp/merged_prs.json
+          jq --arg start "$START_DATE" 'flatten | map(select(.merged_at != null and .merged_at > $start)) | sort_by(.merged_at)' /tmp/all_prs.json > /tmp/merged_prs.json
 
           COUNT=$(jq 'length' /tmp/merged_prs.json)
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to automate release decisions on pushes to main using Claude Sonnet.

## What it does
- Runs on push to main and workflow_dispatch
- Debounces rapid pushes via concurrency cancellation
- Analyzes merged PRs since latest tag
- Uses CI_ANTHROPIC_KEY + Sonnet to decide none/patch/minor
- Blocks major bumps in CI
- Bumps package.json version (+ lockfile if present)
- Commits, tags, pushes, and creates GitHub Release with changelog
- Supports [skip release] opt-out and idempotency checks

## Notes
Uses GITHUB_TOKEN with minimal permissions (contents: write, pull-requests: read).