### PR TITLE
feat: add TUI dashboard extension for at-a-glance system status

### DIFF
--- a/pi/extensions/dashboard.ts
+++ b/pi/extensions/dashboard.ts
@@ -492,42 +492,31 @@ export default function dashboardExtension(pi: ExtensionAPI): void {
     }, REFRESH_INTERVAL_MS);
   });
 
-  // Track last event from inbound messages
-  pi.on("message_start", async (event) => {
-    const msg = event.message as any;
-    if (!msg) return;
+  // Track last event from inbound messages.
+  // before_agent_start fires for ALL inbound messages — user prompts, custom
+  // messages (session-message from Slack bridge, heartbeat), etc.
+  pi.on("before_agent_start", async (event) => {
+    const prompt = event.prompt ?? "";
 
-    if (msg.role === "user") {
-      const text = Array.isArray(msg.content)
-        ? msg.content.find((c: any) => c.type === "text")?.text ?? ""
-        : String(msg.content ?? "");
-
-      if (text.includes("EXTERNAL_UNTRUSTED_CONTENT")) {
-        // Slack message — extract source info
-        const fromMatch = text.match(/From:\s*(<@[^>]+>|[^\n]+)/);
-        const from = fromMatch ? fromMatch[1].trim() : "user";
-        lastEvent = { source: "slack", summary: from, time: new Date() };
-      } else if (text.length > 0) {
-        const preview = text.substring(0, 50).replace(/\n/g, " ");
-        lastEvent = { source: "chat", summary: preview, time: new Date() };
-      }
-    } else if (msg.customType === "heartbeat") {
+    if (prompt.includes("EXTERNAL_UNTRUSTED_CONTENT")) {
+      // Slack message via bridge — extract sender
+      const fromMatch = prompt.match(/From:\s*(<@[^>]+>|[^\n]+)/);
+      const from = fromMatch ? fromMatch[1].trim() : "user";
+      // Extract the actual message content after the --- separator
+      const bodyMatch = prompt.match(/---\n([\s\S]*?)<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>/);
+      const body = bodyMatch ? bodyMatch[1].trim().substring(0, 40).replace(/\n/g, " ") : "";
+      const summary = body ? `${from}: ${body}` : from;
+      lastEvent = { source: "slack", summary, time: new Date() };
+    } else if (prompt.includes("Heartbeat")) {
       lastEvent = { source: "heartbeat", summary: "health check fired", time: new Date() };
-    } else if (msg.customType === "session-message") {
-      // RPC / session-control message
-      const text = String(msg.content ?? "").substring(0, 50).replace(/\n/g, " ");
-      if (text.includes("EXTERNAL_UNTRUSTED_CONTENT")) {
-        const fromMatch = text.match(/From:\s*(<@[^>]+>|[^\n]+)/);
-        const from = fromMatch ? fromMatch[1].trim() : "unknown";
-        lastEvent = { source: "slack", summary: from, time: new Date() };
-      } else if (text.includes("sentry") || text.includes("Sentry")) {
-        lastEvent = { source: "sentry", summary: text.substring(0, 40), time: new Date() };
-      } else {
-        lastEvent = { source: "rpc", summary: text || "message", time: new Date() };
-      }
+    } else if (prompt.includes("#bots-sentry") || prompt.includes("Sentry")) {
+      const preview = prompt.substring(0, 50).replace(/\n/g, " ");
+      lastEvent = { source: "sentry", summary: preview, time: new Date() };
+    } else if (prompt.length > 0) {
+      const preview = prompt.substring(0, 50).replace(/\n/g, " ");
+      lastEvent = { source: "chat", summary: preview, time: new Date() };
     }
 
-    // Update dashboard data immediately
     if (data && lastEvent) {
       data.lastEvent = lastEvent;
     }


### PR DESCRIPTION
## What

Adds a new pi extension (`pi/extensions/dashboard.ts`) that renders a persistent status widget above the editor. When an admin attaches to the running baudbot tmux session, they can see system health at a glance **without querying the agent**.

## Dashboard layout

```
──────────────────────────────────── baudbot ────────────────────────────────────
  baudbot v0.1.0@e004988  │  pi v0.52.12*  │  ● bridge up broker        up 4h 23m
  ● control-agent  ● sentry-agent
  todos 0 active / 31 done / 33 total  │  ○ 0 worktrees              ⟳ 08:45:12
  heartbeat ♥ 3m ago  │  [slack] <@U0123ABC> 12m ago
────────────────────────────────────────────────────────────────────────────────
```

## What's shown

| Indicator | Details |
|-----------|---------|
| **baudbot version** | package.json version + deployed git SHA from `/opt/baudbot/current` |
| **pi version** | Running version, yellow with `*` if behind latest npm |
| **bridge** | Green/red dot, up/DOWN, broker vs socket mode |
| **sessions** | Green/red dots for control-agent & sentry-agent, dev-agent count |
| **todos** | Active (in-progress) / done / total |
| **worktrees** | Count of active git worktrees |
| **heartbeat** | ♥ with last check time + healthy/unhealthy color, or paused |
| **last event** | Source tag (slack/chat/sentry/heartbeat/rpc) + summary + time ago |
| **uptime** | Session uptime (live-updated on every render) |

## Design

- Refreshes every **30 seconds** with **zero LLM token cost** — all data collected via filesystem reads and HTTP probes
- `/dashboard` command for immediate manual refresh
- Pi version read from `package.json` via `process.execPath` (no subprocess)
- Bridge probed via HTTP POST to `localhost:7890/send` (expects 400)
- Bridge type detected from running process (`ps`)
- Heartbeat state read from session entries (cross-extension)
- Last event tracked via `message_start` listener
