### PR TITLE
feat: replace `baudbot attach` with `baudbot debug`

### DIFF
--- a/bin/baudbot
+++ b/bin/baudbot
@@ -50,6 +50,7 @@ json_get_string_stdin_or_empty() {
 }
 
 # Colors (disabled if not a terminal)
+# shellcheck disable=SC2034  # YELLOW used by sourced scripts (config.sh)
 if [ -t 1 ]; then
   BOLD='\033[1m'
   DIM='\033[2m'

--- a/bin/baudbot.test.sh
+++ b/bin/baudbot.test.sh
@@ -59,7 +59,7 @@ test_status_dispatches_via_runtime_module() {
 cmd_status() { echo "status-dispatch-ok"; }
 cmd_logs() { echo "logs-dispatch-ok"; }
 cmd_sessions() { echo "sessions-dispatch-ok"; }
-cmd_attach() { echo "attach-dispatch-ok"; }
+cmd_debug() { echo "debug-dispatch-ok"; }
 has_systemd() { return 1; }
 EOF
 
@@ -68,7 +68,7 @@ EOF
   )
 }
 
-test_attach_requires_root() {
+test_debug_requires_root() {
   (
     set -euo pipefail
     local tmp fakebin out
@@ -89,12 +89,12 @@ fi
 EOF
     chmod +x "$fakebin/id"
 
-    if PATH="$fakebin:$PATH" BAUDBOT_ROOT="$REPO_ROOT" bash "$CLI" attach >/tmp/baudbot-attach.out 2>&1; then
+    if PATH="$fakebin:$PATH" BAUDBOT_ROOT="$REPO_ROOT" bash "$CLI" debug >/tmp/baudbot-debug.out 2>&1; then
       return 1
     fi
 
-    out="$(cat /tmp/baudbot-attach.out)"
-    rm -f /tmp/baudbot-attach.out
+    out="$(cat /tmp/baudbot-debug.out)"
+    rm -f /tmp/baudbot-debug.out
     printf '%s\n' "$out" | grep -q "requires root"
   )
 }
@@ -148,7 +148,7 @@ has_systemd() { return 0; }
 cmd_status() { :; }
 cmd_logs() { :; }
 cmd_sessions() { :; }
-cmd_attach() { :; }
+cmd_debug() { :; }
 EOF
 
     cat > "$fakebin/id" <<'EOF'
@@ -189,7 +189,7 @@ echo ""
 
 run_test "version reads package.json" test_version_uses_package_json
 run_test "status dispatches via runtime module" test_status_dispatches_via_runtime_module
-run_test "attach requires root" test_attach_requires_root
+run_test "debug requires root" test_debug_requires_root
 run_test "broker register requires root" test_broker_register_requires_root
 run_test "restart restarts systemd" test_restart_restarts_systemd
 

--- a/bin/lib/baudbot-runtime.sh
+++ b/bin/lib/baudbot-runtime.sh
@@ -486,6 +486,12 @@ cmd_debug() {
     fi
   fi
 
+  # Validate MODEL — must be a safe provider/model string (alphanumeric, hyphens, dots, slashes)
+  if [[ ! "$MODEL" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+    echo "❌ Invalid model name: $MODEL"
+    exit 1
+  fi
+
   local SKILL_DIR="$AGENT_HOME/.pi/agent/skills/debug-agent"
   if [ ! -f "$SKILL_DIR/SKILL.md" ]; then
     # Fall back to deployed location

--- a/pi/extensions/heartbeat.test.mjs
+++ b/pi/extensions/heartbeat.test.mjs
@@ -8,16 +8,11 @@
  * Run: npx vitest run pi/extensions/heartbeat.test.mjs
  */
 
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
 
 // ── Replicate pure functions from heartbeat.ts v2 ───────────────────────────
 
-const DEFAULT_INTERVAL_MS = 10 * 60 * 1000; // 10 min
-const MIN_INTERVAL_MS = 2 * 60 * 1000; // 2 min
 const BACKOFF_MULTIPLIER = 2;
 const MAX_BACKOFF_MS = 60 * 60 * 1000; // 1 hour
 const STUCK_TODO_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
@@ -69,23 +64,6 @@ function parseTodo(content) {
 }
 
 // ── Test helpers ────────────────────────────────────────────────────────────
-
-let tmpDir;
-
-function setup() {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "heartbeat-test-"));
-}
-
-function teardown() {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
-}
-
-function writeFile(name, content) {
-  const p = path.join(tmpDir, name);
-  fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, content, "utf-8");
-  return p;
-}
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 

--- a/pi/extensions/heartbeat.ts
+++ b/pi/extensions/heartbeat.ts
@@ -25,7 +25,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 const DEFAULT_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 const MIN_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
@@ -270,7 +270,7 @@ function checkStuckTodos(): CheckResult[] {
         if (!createdAt) continue;
 
         const createdTime = new Date(createdAt).getTime();
-        if (isNaN(createdTime)) continue;
+        if (Number.isNaN(createdTime)) continue;
 
         const age = now - createdTime;
         if (age < STUCK_TODO_THRESHOLD_MS) continue;
@@ -341,7 +341,7 @@ function hasMatchingInProgressTodo(worktreeName: string): boolean {
           if (content.includes(pathPattern) || boundaryPattern.test(content)) return true;
         }
       } catch {
-        continue;
+        // skip unreadable todo files
       }
     }
   } catch {
@@ -460,7 +460,7 @@ export default function heartbeatExtension(pi: ExtensionAPI): void {
 
       state.consecutiveErrors = 0;
       saveState();
-    } catch (err) {
+    } catch {
       state.consecutiveErrors += 1;
       try {
         saveState();


### PR DESCRIPTION
## Summary

The old `baudbot attach` command was fundamentally broken — it spawned a **new** pi instance connected to the control-agent's control socket instead of actually attaching to the running session. This created a duplicate agent, causing:
- Two control-agents responding to Slack messages
- Bridge routing conflicts (old vs new session UUIDs)
- Confusion about which session was "real"

## Changes

Replace `baudbot attach` with `baudbot debug`, which launches the **debug-agent skill** — a dedicated observability tool.

### What `baudbot debug` does:
- Launches a separate pi instance with the debug-agent skill + live dashboard extension
- Dashboard shows: health metrics, bridge status, sessions, todos, worktrees, heartbeat state
- Activity feed tails the control-agent's session log in real-time
- Has `--session-control` so you can `send_to_session` to query running agents
- `Ctrl+C` exits cleanly without affecting the control-agent

### Usage:
```bash
sudo baudbot debug                           # auto-detect model
sudo baudbot debug --model anthropic/claude-sonnet-4-5  # explicit model
```

### Model auto-detection:
Reads API keys from `~/.config/.env` and picks a mid-tier model:
- `ANTHROPIC_API_KEY` → `anthropic/claude-sonnet-4-5`
- `OPENAI_API_KEY` → `openai/gpt-4.1`
- `GEMINI_API_KEY` → `google/gemini-3-flash-preview`
- `BAUDBOT_MODEL` override takes priority

### Removed:
- `cmd_attach`, `pause_before_attach`, `--pi`/`--tmux` mode flags
- All session-attach logic that spawned duplicate agents

### Technical notes:
- Unsets `PKG_EXECPATH` before launching to avoid varlock poisoning
- Requires root (`sudo`) — consistent with other admin commands
- Skill dir lookup: `~/.pi/agent/skills/debug-agent` → `/opt/baudbot/current/pi/skills/debug-agent`

## Testing
- `bin/test.sh`: 13/15 pass (2 pre-existing failures on main: heartbeat, memory)