### PR TITLE
ci: fix GitHub Actions expression syntax in release-on-main workflow

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -268,7 +268,7 @@ jobs:
           echo "Reason: ${{ steps.decide.outputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dry-run release summary
-        if: steps.bump.outputs.tag != "" && steps.dryrun.outputs.enabled == "true"
+        if: steps.bump.outputs.tag != '' && steps.dryrun.outputs.enabled == 'true'
         run: |
           echo "## Dry run: no release published" >> "$GITHUB_STEP_SUMMARY"
           echo "Decision: ${{ steps.decide.outputs.decision }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

GitHub Actions reports:

```
Invalid workflow file: .github/workflows/release-on-main.yml#L1
(Line: 271, Col: 13): Unexpected symbol: '""'. Located at position 27 within expression:
steps.bump.outputs.tag != "" && steps.dryrun.outputs.enabled == "true"
```

The `Dry-run release summary` step's `if:` condition used double quotes (`""`) for string literals. GitHub Actions expressions only support single quotes for strings.

## Fix

Replace double quotes with single quotes on line 271 to match every other `if:` condition in the workflow:

```yaml
# Before
if: steps.bump.outputs.tag != "" && steps.dryrun.outputs.enabled == "true"

# After
if: steps.bump.outputs.tag != '' && steps.dryrun.outputs.enabled == 'true'
```

## Validation

- ✅ `yaml-lint` — passes
- ✅ `actionlint` — no errors (only optional shellcheck style hints)