### PR TITLE
fix: allow root as admin user for broker register and config

### DIFF
--- a/bin/broker-register.mjs
+++ b/bin/broker-register.mjs
@@ -374,13 +374,16 @@ export function resolveConfigTargets({ env = process.env } = {}) {
   let adminUser;
   if (explicitConfigUser) {
     adminUser = explicitConfigUser;
-  } else if (isRoot) {
+  } else if (isRoot && sudoUser) {
     adminUser = sudoUser;
+  } else if (isRoot) {
+    // Running directly as root (no sudo) — use root as the admin user.
+    adminUser = "root";
   } else {
     adminUser = os.userInfo().username;
   }
 
-  if (!adminUser || adminUser === "root") {
+  if (!adminUser) {
     throw new Error("could not determine admin user (run as: sudo baudbot broker register)");
   }
 

--- a/bin/broker-register.test.mjs
+++ b/bin/broker-register.test.mjs
@@ -14,6 +14,8 @@ import {
   upsertEnvContent,
   runRegistration,
   isMainModule,
+  lookupUser,
+  resolveConfigTargets,
 } from "./broker-register.mjs";
 
 const FIXTURE_SERVER_KEYS = {
@@ -306,4 +308,36 @@ test("upsertEnvContent updates existing values and appends new ones", () => {
   assert.match(next, /SLACK_ALLOWED_USERS=U3,U4/);
   assert.match(next, /SLACK_BROKER_URL=https:\/\/broker\.example\.com/);
   assert.match(next, /SLACK_BOT_TOKEN=xoxb-old/);
+});
+
+test("lookupUser parses passwd entries correctly", () => {
+  const passwdText = [
+    "root:x:0:0:root:/root:/bin/bash",
+    "nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin",
+    "baudbot_agent:x:1001:1001::/home/baudbot_agent:/bin/bash",
+  ].join("\n");
+
+  const root = lookupUser("root", passwdText);
+  assert.deepEqual(root, { username: "root", uid: 0, gid: 0, home: "/root" });
+
+  const agent = lookupUser("baudbot_agent", passwdText);
+  assert.deepEqual(agent, { username: "baudbot_agent", uid: 1001, gid: 1001, home: "/home/baudbot_agent" });
+
+  assert.equal(lookupUser("missing", passwdText), null);
+});
+
+test("resolveConfigTargets uses BAUDBOT_CONFIG_USER when set", () => {
+  const currentUser = os.userInfo().username;
+  // Use BAUDBOT_CONFIG_USER to override admin user detection
+  const targets = resolveConfigTargets({ env: { BAUDBOT_CONFIG_USER: currentUser } });
+  assert.ok(targets.length >= 1);
+  assert.equal(targets[0].user, currentUser);
+  assert.equal(targets[0].label, "admin");
+});
+
+test("resolveConfigTargets throws for unknown BAUDBOT_CONFIG_USER", () => {
+  assert.throws(
+    () => resolveConfigTargets({ env: { BAUDBOT_CONFIG_USER: "no_such_user_xyz" } }),
+    /admin user not found/,
+  );
 });

--- a/bin/config.sh
+++ b/bin/config.sh
@@ -223,10 +223,6 @@ if [ -n "${BAUDBOT_CONFIG_USER:-}" ]; then
   CONFIG_USER="$BAUDBOT_CONFIG_USER"
 elif [ "$(id -u)" -eq 0 ]; then
   CONFIG_USER="${SUDO_USER:-root}"
-  if [ "$CONFIG_USER" = "root" ]; then
-    echo "Run as: sudo baudbot config (not as root directly)"
-    exit 1
-  fi
 else
   CONFIG_USER="$(whoami)"
 fi
@@ -246,7 +242,7 @@ CONFIG_DIR="$CONFIG_HOME/.baudbot"
 CONFIG_FILE="$CONFIG_DIR/.env"
 
 mkdir -p "$CONFIG_DIR"
-# Ensure owned by the admin user (not root)
+# Ensure owned by the admin user (may be root when running directly as root)
 if [ "$(id -u)" -eq 0 ]; then
   chown "$CONFIG_USER:$CONFIG_USER" "$CONFIG_DIR"
 fi

--- a/bin/config.test.sh
+++ b/bin/config.test.sh
@@ -18,8 +18,7 @@ run_config() {
   local home="$1"
   local input="$2"
   local config_user
-  # config.sh exits when run as root unless BAUDBOT_CONFIG_USER is set.
-  # CI shell tests run as root on droplets, so force an explicit target user.
+  # CI shell tests set BAUDBOT_CONFIG_USER explicitly for deterministic paths.
   config_user="$(id -un)"
   mkdir -p "$home"
   printf "%b" "$input" \
@@ -61,7 +60,7 @@ expect_file_not_contains() {
 expect_exit_nonzero() {
   local desc="$1" home="$2" input="$3"
   local config_user
-  # Same reason as run_config(): make behavior deterministic under root CI runs.
+  # Same as run_config(): deterministic target user for CI.
   config_user="$(id -un)"
   set +e
   printf "%b" "$input" \


### PR DESCRIPTION
## Problem

`baudbot broker register` and `baudbot config` fail when run directly as root (not via sudo):

```
root@server:~# sudo baudbot broker register
❌ could not determine admin user (run as: sudo baudbot broker register)
```

Both commands explicitly rejected `root` as the admin user. While sudo is the typical path, running directly as root is a valid deployment scenario (e.g. single-user VPS).

## Root cause

**`broker-register.mjs` (`resolveConfigTargets`):**
- When `isRoot && !SUDO_USER`, `adminUser` was `undefined` (fell into the sudo branch with no `SUDO_USER`)
- Even if it resolved to `"root"`, the guard `adminUser === "root"` rejected it

**`config.sh`:**
- Explicit check: `if [ "$CONFIG_USER" = "root" ]; then exit 1`

Meanwhile, the other shell scripts (`env.sh`, `render-env.sh`, `doctor.sh`) already handled this correctly via `${SUDO_USER:-root}` fallbacks.

## Fix

- **`broker-register.mjs`**: Split the `isRoot` branch — use `SUDO_USER` when set, otherwise accept `"root"`. Drop the `=== "root"` rejection from the guard.
- **`config.sh`**: Remove the root rejection block. `chown root:root` on root-owned files is a no-op, so the downstream ownership logic is safe.
- **Tests**: Add `lookupUser` and `resolveConfigTargets` tests to `broker-register.test.mjs`; update stale comments in `config.test.sh`.

## Verification

- `npm test` — 138 tests pass
- `npm run lint` — clean (biome + shellcheck)