### PR TITLE
Fix: Aggressively kill all bridge processes on startup

### DIFF
--- a/pi/skills/control-agent/startup-pi.sh
+++ b/pi/skills/control-agent/startup-pi.sh
@@ -98,24 +98,35 @@ echo "Cleaning up old bridge..."
 # the bridge while we're trying to clean up the port.
 tmux kill-session -t "$BRIDGE_TMUX_SESSION" 2>/dev/null || true
 
-# Now gracefully stop any process on the port. SIGTERM lets the bridge close
-# the HTTP server and release the port cleanly; SIGKILL is the fallback.
-PORT_PIDS=$(lsof -ti :7890 2>/dev/null || true)
-if [ -n "$PORT_PIDS" ]; then
-  echo "Stopping processes on port 7890 (SIGTERM): $PORT_PIDS"
-  echo "$PORT_PIDS" | xargs kill 2>/dev/null || true
+# Kill ALL bridge processes (broker-bridge.mjs and bridge.mjs) to prevent
+# orphaned processes from holding port 7890 after control-agent restarts.
+# This is more aggressive than just killing port holders, but prevents the
+# common failure mode where a bridge process survives tmux session cleanup
+# (e.g., detached, zombied, or in a different session tree).
+BRIDGE_PIDS=$(pgrep -f 'node (broker-)?bridge\.mjs' 2>/dev/null || true)
+if [ -n "$BRIDGE_PIDS" ]; then
+  echo "Killing all bridge processes (SIGTERM): $BRIDGE_PIDS"
+  echo "$BRIDGE_PIDS" | xargs kill 2>/dev/null || true
   # Wait up to 3s for graceful shutdown
   for i in 1 2 3; do
     sleep 1
-    PORT_PIDS=$(lsof -ti :7890 2>/dev/null || true)
-    [ -z "$PORT_PIDS" ] && break
+    BRIDGE_PIDS=$(pgrep -f 'node (broker-)?bridge\.mjs' 2>/dev/null || true)
+    [ -z "$BRIDGE_PIDS" ] && break
   done
   # Force-kill anything that didn't exit
-  if [ -n "$PORT_PIDS" ]; then
-    echo "Force-killing stubborn processes: $PORT_PIDS"
-    echo "$PORT_PIDS" | xargs kill -9 2>/dev/null || true
+  if [ -n "$BRIDGE_PIDS" ]; then
+    echo "Force-killing stubborn bridge processes: $BRIDGE_PIDS"
+    echo "$BRIDGE_PIDS" | xargs kill -9 2>/dev/null || true
     sleep 1
   fi
+fi
+
+# Final safety check: kill anything still on port 7890
+PORT_PIDS=$(lsof -ti :7890 2>/dev/null || true)
+if [ -n "$PORT_PIDS" ]; then
+  echo "Force-killing remaining processes on port 7890: $PORT_PIDS"
+  echo "$PORT_PIDS" | xargs kill -9 2>/dev/null || true
+  sleep 1
 fi
 
 OLD_PID_FILE="$HOME/.pi/agent/slack-bridge.pid"


### PR DESCRIPTION
## Problem

The slack-bridge frequently fails to start with EADDRINUSE on port 7890 after control-agent restarts. This happens because:

1. Control-agent restarts with a new session ID
2. `startup-pi.sh` kills the tmux session and tries to kill port holders
3. But a bridge process sometimes survives (detached, zombied, or in a wrong session tree)
4. The orphaned process holds port 7890, causing the new bridge to crash-loop

## Solution

Make the cleanup more aggressive:

1. Kill tmux session (stops the restart loop)
2. Kill ALL bridge processes by pattern matching `node (broker-)?bridge\.mjs`
   - Use SIGTERM first for graceful shutdown
   - Wait 3s, then SIGKILL stragglers
3. Final safety check: kill anything still on port 7890

This ensures no bridge processes survive across control-agent restarts.

## Testing

- Manually tested cleanup logic
- Verified pgrep pattern matches both `bridge.mjs` and `broker-bridge.mjs`
- Confirmed graceful SIGTERM → SIGKILL fallback works

## Impact

- Prevents the common port 7890 conflict that requires manual intervention
- Makes control-agent restarts more reliable
- No change to normal operation (only affects startup cleanup)