### PR TITLE
deploy: force-fetch branch tip after clone to defeat stale refs

### DIFF
--- a/bin/update-release.sh
+++ b/bin/update-release.sh
@@ -393,6 +393,12 @@ fi
 log "cloning update source"
 git clone --quiet --single-branch --branch "$BRANCH" "$REPO_URL" "$CHECKOUT_DIR"
 
+# Force-refresh the branch tip to defeat transport-level caching (GitHub CDN,
+# HTTP proxies, stale local mirrors).  Without this, `git clone` can serve a
+# ref advertisement that is minutes-to-days behind the true remote HEAD.
+git -C "$CHECKOUT_DIR" fetch --quiet --force --no-tags origin "$BRANCH"
+git -C "$CHECKOUT_DIR" reset --quiet --hard "origin/$BRANCH"
+
 if [ -n "$BAUDBOT_UPDATE_REF" ]; then
   log "checking out ref: $BAUDBOT_UPDATE_REF"
   git -C "$CHECKOUT_DIR" fetch --quiet origin "$BAUDBOT_UPDATE_REF"

--- a/bin/update-release.test.sh
+++ b/bin/update-release.test.sh
@@ -252,6 +252,37 @@ test_release_root_overrides_stale_source_path_env() {
   )
 }
 
+test_update_picks_up_latest_commit() {
+  (
+    set -euo pipefail
+    local tmp repo release_root sha1 sha2 current_sha
+
+    tmp="$(mktemp -d /tmp/baudbot-update-test.XXXXXX)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    repo="$tmp/repo"
+    release_root="$tmp/opt/baudbot"
+
+    make_repo "$repo"
+    sha1="$(git -C "$repo" rev-parse HEAD)"
+
+    run_update "$repo" "$release_root" "test -f hello.txt"
+
+    current_sha="$(readlink -f "$release_root/current")"
+    [ "$current_sha" = "$release_root/releases/$sha1" ]
+
+    # Push a new commit and update again — must land on the new SHA.
+    new_commit "$repo" "latest-tip"
+    sha2="$(git -C "$repo" rev-parse HEAD)"
+    [ "$sha1" != "$sha2" ]
+
+    run_update "$repo" "$release_root" "test -f hello.txt"
+
+    current_sha="$(readlink -f "$release_root/current")"
+    [ "$current_sha" = "$release_root/releases/$sha2" ]
+  )
+}
+
 test_resolve_npm_from_fake_agent_home() {
   (
     set -euo pipefail
@@ -364,6 +395,7 @@ run_test "publishes git-free release snapshot" test_publish_git_free_release
 run_test "preflight failure keeps current release" test_preflight_failure_keeps_current
 run_test "deploy failure keeps current release" test_deploy_failure_keeps_current
 run_test "release root overrides stale source env" test_release_root_overrides_stale_source_path_env
+run_test "update picks up latest commit" test_update_picks_up_latest_commit
 run_test "resolves npm from agent embedded runtime" test_resolve_npm_from_fake_agent_home
 run_test "resolves npm from sudo user home" test_resolve_npm_from_fake_sudo_user_home
 run_test "resolve_npm_bin fails when npm missing" test_resolve_npm_fails_when_missing


### PR DESCRIPTION
## Problem

`baudbot update` sometimes deploys commits that are days behind the true remote HEAD. Observed on DigitalOcean droplets.

## Root cause

`git clone --single-branch --branch main` relies on the remote's ref advertisement, which can be stale due to:
- **GitHub's HTTPS smart transport CDN caching** — edge nodes can lag behind by minutes to hours
- **HTTP proxy caching** on the host or network
- **Local path repos** that haven't been fetched recently (when `REPO_URL` resolves to a local checkout)

## Fix

After cloning, explicitly `git fetch --force` the branch and `git reset --hard origin/<branch>` to guarantee the checkout reflects the actual latest tip, bypassing any transport-level caching.

## Changes

- **`bin/update-release.sh`** — added force-fetch + hard-reset after clone
- **`bin/update-release.test.sh`** — added test confirming sequential updates pick up new commits

## Testing

- All existing tests pass (`5/5`)
- Shell lint clean (`59 files`)
- Full shell test suite green (`15/15`)