### PR TITLE
Fix varlock path compatibility for debug/startup/subagents

### DIFF
--- a/bin/baudbot.service
+++ b/bin/baudbot.service
@@ -22,7 +22,7 @@ Restart=on-failure
 RestartSec=10
 
 # Environment
-Environment=PATH=/home/baudbot_agent/.varlock/bin:/home/baudbot_agent/opt/node/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/home/baudbot_agent/.varlock/bin:/home/baudbot_agent/.config/varlock/bin:/home/baudbot_agent/opt/node/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=/home/baudbot_agent
 
 # Security hardening

--- a/bin/ci/setup-arch.sh
+++ b/bin/ci/setup-arch.sh
@@ -77,10 +77,10 @@ echo "$CLI_TARGET" | grep -qE '^/opt/baudbot/releases/.+/bin/baudbot$'
 baudbot --version
 HELP_OUT=$(baudbot --help)
 echo "$HELP_OUT" | grep -q "baudbot"
-# varlock installed for agent user
-test -x /home/baudbot_agent/.varlock/bin/varlock
+# varlock installed for agent user (supports both legacy and current install paths)
+test -x /home/baudbot_agent/.varlock/bin/varlock || test -x /home/baudbot_agent/.config/varlock/bin/varlock
 # Agent can load env (smoke test — varlock validates schema + .env)
-sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/opt/node/bin:$PATH" && cd ~ && varlock load --path ~/.config/'
+sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$HOME/opt/node/bin:$PATH" && cd ~ && varlock load --path ~/.config/'
 echo "  ✓ bootstrap + install verification passed"
 
 echo "=== Running CLI smoke checks ==="

--- a/bin/ci/setup-ubuntu.sh
+++ b/bin/ci/setup-ubuntu.sh
@@ -96,10 +96,10 @@ echo "$CLI_TARGET" | grep -qE '^/opt/baudbot/releases/.+/bin/baudbot$'
 baudbot --version
 HELP_OUT=$(baudbot --help)
 echo "$HELP_OUT" | grep -q "baudbot"
-# varlock installed for agent user
-test -x /home/baudbot_agent/.varlock/bin/varlock
+# varlock installed for agent user (supports both legacy and current install paths)
+test -x /home/baudbot_agent/.varlock/bin/varlock || test -x /home/baudbot_agent/.config/varlock/bin/varlock
 # Agent can load env (smoke test — varlock validates schema + .env)
-sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/opt/node/bin:$PATH" && cd ~ && varlock load --path ~/.config/'
+sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$HOME/opt/node/bin:$PATH" && cd ~ && varlock load --path ~/.config/'
 echo "  ✓ bootstrap + install verification passed"
 
 echo "=== Running CLI smoke checks ==="

--- a/bin/doctor.sh
+++ b/bin/doctor.sh
@@ -80,10 +80,12 @@ if [ -n "${BAUDBOT_ROOT:-}" ] && command -v rg &>/dev/null; then
   fi
 fi
 
-if command -v varlock &>/dev/null || [ -x "$BAUDBOT_HOME/.varlock/bin/varlock" ]; then
+if command -v varlock &>/dev/null || [ -x "$BAUDBOT_HOME/.varlock/bin/varlock" ] || [ -x "$BAUDBOT_HOME/.config/varlock/bin/varlock" ]; then
   pass "varlock is installed"
   if [ -f "$BAUDBOT_HOME/.varlock/config.json" ] && grep -q '"anonymousId"' "$BAUDBOT_HOME/.varlock/config.json"; then
     warn "$BAUDBOT_HOME/.varlock/config.json includes anonymousId (export VARLOCK_TELEMETRY_DISABLED=1 or remove this field)"
+  elif [ -f "$BAUDBOT_HOME/.config/varlock/config.json" ] && grep -q '"anonymousId"' "$BAUDBOT_HOME/.config/varlock/config.json"; then
+    warn "$BAUDBOT_HOME/.config/varlock/config.json includes anonymousId (export VARLOCK_TELEMETRY_DISABLED=1 or remove this field)"
   fi
 else
   fail "varlock not found"

--- a/bin/doctor.sh
+++ b/bin/doctor.sh
@@ -84,7 +84,8 @@ if command -v varlock &>/dev/null || [ -x "$BAUDBOT_HOME/.varlock/bin/varlock" ]
   pass "varlock is installed"
   if [ -f "$BAUDBOT_HOME/.varlock/config.json" ] && grep -q '"anonymousId"' "$BAUDBOT_HOME/.varlock/config.json"; then
     warn "$BAUDBOT_HOME/.varlock/config.json includes anonymousId (export VARLOCK_TELEMETRY_DISABLED=1 or remove this field)"
-  elif [ -f "$BAUDBOT_HOME/.config/varlock/config.json" ] && grep -q '"anonymousId"' "$BAUDBOT_HOME/.config/varlock/config.json"; then
+  fi
+  if [ -f "$BAUDBOT_HOME/.config/varlock/config.json" ] && grep -q '"anonymousId"' "$BAUDBOT_HOME/.config/varlock/config.json"; then
     warn "$BAUDBOT_HOME/.config/varlock/config.json includes anonymousId (export VARLOCK_TELEMETRY_DISABLED=1 or remove this field)"
   fi
 else

--- a/bin/lib/baudbot-runtime.sh
+++ b/bin/lib/baudbot-runtime.sh
@@ -519,7 +519,7 @@ cmd_debug() {
 
   exec sudo -u "$AGENT_USER" bash -lc "
     unset PKG_EXECPATH
-    export PATH='$AGENT_HOME/.varlock/bin:$node_bin_dir':\$PATH
+    export PATH='$AGENT_HOME/.varlock/bin:$AGENT_HOME/.config/varlock/bin:$node_bin_dir':\$PATH
     export VARLOCK_TELEMETRY_DISABLED=1
     cd ~
     varlock run --path ~/.config/ -- pi \

--- a/bin/subagents.sh
+++ b/bin/subagents.sh
@@ -283,7 +283,7 @@ spawn_one() {
   sudo -u "$AGENT_USER" mkdir -p "$AGENT_HOME/.pi/agent/logs"
 
   local tmux_cmd
-  tmux_cmd="cd $(shell_quote "$cwd") && export PATH=\"\$HOME/.varlock/bin:\$HOME/opt/node/bin:\$PATH\" && export PI_SESSION_NAME=$(shell_quote "$session_name") && exec varlock run --path \"\$HOME/.config/\" -- pi --session-control --skill $(shell_quote "$skill_path") --model $(shell_quote "$model") > $(shell_quote "$log_path") 2>&1"
+  tmux_cmd="cd $(shell_quote "$cwd") && export PATH=\"\$HOME/.varlock/bin:\$HOME/.config/varlock/bin:\$HOME/opt/node/bin:\$PATH\" && export PI_SESSION_NAME=$(shell_quote "$session_name") && exec varlock run --path \"\$HOME/.config/\" -- pi --session-control --skill $(shell_quote "$skill_path") --model $(shell_quote "$model") > $(shell_quote "$log_path") 2>&1"
   sudo -u "$AGENT_USER" tmux new-session -d -s "$session_name" "$tmux_cmd"
 
   local alias_path="$CONTROL_DIR/$ready_alias.alias"

--- a/setup.sh
+++ b/setup.sh
@@ -252,10 +252,17 @@ echo "=== Installing varlock ==="
 # varlock must be available to the agent user (start.sh adds ~/.varlock/bin to PATH).
 # Install as agent user so it lands in the right home directory.
 AGENT_VARLOCK="$BAUDBOT_HOME/.varlock/bin/varlock"
-if [ -x "$AGENT_VARLOCK" ]; then
+AGENT_VARLOCK_CONFIG_BIN="$BAUDBOT_HOME/.config/varlock/bin/varlock"
+if [ -x "$AGENT_VARLOCK" ] || [ -x "$AGENT_VARLOCK_CONFIG_BIN" ]; then
   echo "varlock already installed for baudbot_agent, skipping"
 else
   sudo -u baudbot_agent bash -c 'curl -sSfL https://varlock.dev/install.sh | sh -s'
+fi
+
+# Newer varlock installers place the binary under ~/.config/varlock/bin.
+# Keep a compatibility link at ~/.varlock/bin/varlock for existing runtime scripts.
+if [ -x "$AGENT_VARLOCK_CONFIG_BIN" ]; then
+  sudo -u baudbot_agent bash -c "mkdir -p '$BAUDBOT_HOME/.varlock/bin' && ln -sf '$AGENT_VARLOCK_CONFIG_BIN' '$AGENT_VARLOCK'"
 fi
 
 echo "=== Publishing initial git-free /opt release ==="

--- a/setup.sh
+++ b/setup.sh
@@ -261,8 +261,13 @@ fi
 
 # Newer varlock installers place the binary under ~/.config/varlock/bin.
 # Keep a compatibility link at ~/.varlock/bin/varlock for existing runtime scripts.
+# If a real legacy binary already exists, preserve it (do not replace with symlink).
 if [ -x "$AGENT_VARLOCK_CONFIG_BIN" ]; then
-  sudo -u baudbot_agent bash -c "mkdir -p '$BAUDBOT_HOME/.varlock/bin' && ln -sf '$AGENT_VARLOCK_CONFIG_BIN' '$AGENT_VARLOCK'"
+  if [ -x "$AGENT_VARLOCK" ] && [ ! -L "$AGENT_VARLOCK" ]; then
+    echo "Keeping existing legacy varlock binary at $AGENT_VARLOCK"
+  else
+    sudo -u baudbot_agent bash -c "mkdir -p '$BAUDBOT_HOME/.varlock/bin' && ln -sfn '$AGENT_VARLOCK_CONFIG_BIN' '$AGENT_VARLOCK'"
+  fi
 fi
 
 echo "=== Publishing initial git-free /opt release ==="

--- a/start.sh
+++ b/start.sh
@@ -18,8 +18,8 @@ cd ~
 
 NODE_BIN_DIR="$(bb_resolve_runtime_node_bin_dir "$HOME")"
 
-# Set PATH
-export PATH="$HOME/.varlock/bin:$NODE_BIN_DIR:$PATH"
+# Set PATH (varlock may be installed in ~/.varlock/bin or ~/.config/varlock/bin)
+export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$NODE_BIN_DIR:$PATH"
 
 # Work around varlock telemetry config crash by opting out at runtime.
 export VARLOCK_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary
- support both varlock install locations in runtime paths:
  - ~/.varlock/bin (legacy)
  - ~/.config/varlock/bin (current installer)
- update startup/service/debug/subagent PATH construction to include both locations
- update setup flow to create a compatibility symlink at ~/.varlock/bin/varlock when varlock is installed under ~/.config/varlock/bin
- update doctor + CI setup checks to accept either location

## Why
Fresh Ubuntu installs can have varlock only at ~/.config/varlock/bin/varlock, which caused `baudbot debug` and other paths that assumed ~/.varlock/bin to fail with `varlock: command not found`.

## Validation
- `npm run lint:shell`
- `npm run test:shell`
- `bash bin/baudbot.test.sh`
