### PR TITLE
docs: add sponsor section to README with UTM-tagged Modem link (GTM-29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,18 @@ npm run lint && npm run typecheck
 npm run lint:shell
 ```
 
+## Sponsor
+
+Sponsored by [Modem](https://modem.dev?utm_source=github&utm_medium=oss&utm_campaign=oss_baudbot&utm_content=readme_footer).
+
+<a href="https://modem.dev?utm_source=github&utm_medium=oss&utm_campaign=oss_baudbot&utm_content=readme_footer">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://modem.dev/images/logo/svg/modem-combined-white.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://modem.dev/images/logo/svg/modem-combined-black.svg">
+    <img src="https://modem.dev/images/logo/svg/modem-combined-black.svg" alt="Modem" width="220">
+  </picture>
+</a>
+
 ## License
 
 MIT
-
-## About
-
-Brought to you by the team at Modem, your dev team's auto-triage product manager.


### PR DESCRIPTION
## Summary

Adds a `## Sponsor` section to the README pointing back to modem.dev with the canonical UTM tagging from the GTM [UTM Tagging Strategy](https://www.notion.so/UTM-Tagging-Strategy-3642c5842de0816cacfdd83ac1d4d6e7). Mirrors the same pattern already shipped in `modem-dev/slop-scan`.

The prior `## About` blurb ("Brought to you by the team at Modem…") was removed — its taglining role overlapped with the sponsor section, and the slop-scan template doesn't carry one.

## Linear

[GTM-29](https://linear.app/modem-dev/issue/GTM-29) — Add "Sponsored by Modem" section to baudbot README with UTM-tagged link

## Changes

- Add `## Sponsor` section above `## License` with text link + dark/light Modem logo
- Sponsor link: `https://modem.dev?utm_source=github&utm_medium=oss&utm_campaign=oss_baudbot&utm_content=readme_footer`
- Remove the prior `## About` section (replaced by the sponsor block)

## Testing

- [x] Section renders correctly in GitHub markdown preview
- [ ] After merge: confirm a `$pageview` lands in PostHog with `utm_campaign=oss_baudbot` within ~24h of the first click

## Related

- UTM Generator row registered for this link (Notion)
- Slop-scan, hunk, podguy still use the older `utm_campaign=<repo>` form — separately tracked in GTM-32 for migration