### PR TITLE
deps: pin varlock to 1.7.1 with reconcile-on-update + telemetry opt-out

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,7 +6,11 @@ All secrets and configuration live in `~/.config/.env` on the agent's home direc
 
 Baudbot uses [Varlock](https://varlock.dev) to validate environment variables at startup. The schema (`.env.schema`) is committed to the repo and deployed to `~/.config/.env.schema` alongside the secrets file. It defines types, required/optional status, and sensitivity for each variable.
 
-`start.sh` runs `varlock load` to validate before launching — the agent won't start with missing or malformed variables. The bridge uses `varlock run` to inject validated env vars. Varlock must be installed on the agent system (`brew install dmno-dev/tap/varlock` or `curl -sSfL https://varlock.dev/install.sh | sh -s`).
+`start.sh` runs `varlock load` to validate before launching — the agent won't start with missing or malformed variables. The bridge uses `varlock run` to inject validated env vars.
+
+Varlock is installed as a standalone binary for the agent user (not an npm dependency, since it runs at the process-supervision layer outside any Node project). `setup.sh` and `baudbot update` both reconcile it to a **pinned version** via `bin/lib/varlock-common.sh` (default `1.7.1`, override with `BAUDBOT_VARLOCK_VERSION`). Because the version is pinned and reconciled on every update, deployed agents stay on a known-good version rather than drifting. Telemetry is disabled at install time (`varlock telemetry disable`) and again at runtime via `VARLOCK_TELEMETRY_DISABLED=1`.
+
+To install manually outside of setup: `curl -sSfL https://varlock.dev/install.sh | sh -s -- --version=1.7.1` (the version is a CLI arg, not an env var), or `brew install dmno-dev/tap/varlock` for the latest.
 
 ## Required Variables
 
@@ -194,6 +198,7 @@ Set during `setup.sh` / `baudbot install` via env vars:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `BAUDBOT_PI_VERSION` | pi package version installed for `baudbot_agent` | `0.52.12` |
+| `BAUDBOT_VARLOCK_VERSION` | varlock version installed/reconciled for `baudbot_agent` (also on `baudbot update`) | `1.7.1` |
 | `BAUDBOT_RUNTIME_NODE_VERSION` | embedded Node.js version downloaded to `~/opt/node-v<version>-linux-x64` (with stable symlink `~/opt/node`) | `22.14.0` |
 | `GIT_USER_NAME` | Git commit author name | `baudbot-agent` |
 | `GIT_USER_EMAIL` | Git commit author email | `baudbot-agent@users.noreply.github.com` |

--- a/bin/ci/setup-arch.sh
+++ b/bin/ci/setup-arch.sh
@@ -79,8 +79,14 @@ HELP_OUT=$(baudbot --help)
 echo "$HELP_OUT" | grep -q "baudbot"
 # varlock installed for agent user (supports both legacy and current install paths)
 test -x /home/baudbot_agent/.varlock/bin/varlock || test -x /home/baudbot_agent/.config/varlock/bin/varlock
+# varlock reconciled to the pinned version (single source: bin/lib/varlock-common.sh)
+# shellcheck source=bin/lib/varlock-common.sh
+source /home/baudbot_admin/baudbot/bin/lib/varlock-common.sh
+EXPECTED_VARLOCK="$(bb_varlock_pinned_version)"
+ACTUAL_VARLOCK="$(sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$PATH" && varlock --version' | head -n1 | tr -d '[:space:]')"
+test "$ACTUAL_VARLOCK" = "$EXPECTED_VARLOCK" || { echo "varlock version mismatch: got '$ACTUAL_VARLOCK', expected '$EXPECTED_VARLOCK'"; exit 1; }
 # Agent can load env (smoke test — varlock validates schema + .env)
-sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$HOME/opt/node/bin:$PATH" && cd ~ && varlock load --path ~/.config/'
+sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$HOME/opt/node/bin:$PATH" && export VARLOCK_TELEMETRY_DISABLED=1 && cd ~ && varlock load --path ~/.config/'
 echo "  ✓ bootstrap + install verification passed"
 
 echo "=== Running CLI smoke checks ==="

--- a/bin/ci/setup-ubuntu.sh
+++ b/bin/ci/setup-ubuntu.sh
@@ -98,8 +98,14 @@ HELP_OUT=$(baudbot --help)
 echo "$HELP_OUT" | grep -q "baudbot"
 # varlock installed for agent user (supports both legacy and current install paths)
 test -x /home/baudbot_agent/.varlock/bin/varlock || test -x /home/baudbot_agent/.config/varlock/bin/varlock
+# varlock reconciled to the pinned version (single source: bin/lib/varlock-common.sh)
+# shellcheck source=bin/lib/varlock-common.sh
+source /home/baudbot_admin/baudbot/bin/lib/varlock-common.sh
+EXPECTED_VARLOCK="$(bb_varlock_pinned_version)"
+ACTUAL_VARLOCK="$(sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$PATH" && varlock --version' | head -n1 | tr -d '[:space:]')"
+test "$ACTUAL_VARLOCK" = "$EXPECTED_VARLOCK" || { echo "varlock version mismatch: got '$ACTUAL_VARLOCK', expected '$EXPECTED_VARLOCK'"; exit 1; }
 # Agent can load env (smoke test — varlock validates schema + .env)
-sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$HOME/opt/node/bin:$PATH" && cd ~ && varlock load --path ~/.config/'
+sudo -u baudbot_agent bash -c 'export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$HOME/opt/node/bin:$PATH" && export VARLOCK_TELEMETRY_DISABLED=1 && cd ~ && varlock load --path ~/.config/'
 echo "  ✓ bootstrap + install verification passed"
 
 echo "=== Running CLI smoke checks ==="

--- a/bin/doctor.sh
+++ b/bin/doctor.sh
@@ -13,6 +13,8 @@ source "$SCRIPT_DIR/lib/paths-common.sh"
 source "$SCRIPT_DIR/lib/doctor-common.sh"
 # shellcheck source=bin/lib/runtime-node.sh
 source "$SCRIPT_DIR/lib/runtime-node.sh"
+# shellcheck source=bin/lib/varlock-common.sh
+source "$SCRIPT_DIR/lib/varlock-common.sh"
 bb_enable_strict_mode
 bb_init_paths
 
@@ -82,12 +84,14 @@ fi
 
 if command -v varlock &>/dev/null || [ -x "$BAUDBOT_HOME/.varlock/bin/varlock" ] || [ -x "$BAUDBOT_HOME/.config/varlock/bin/varlock" ]; then
   pass "varlock is installed"
-  if [ -f "$BAUDBOT_HOME/.varlock/config.json" ] && grep -q '"anonymousId"' "$BAUDBOT_HOME/.varlock/config.json"; then
-    warn "$BAUDBOT_HOME/.varlock/config.json includes anonymousId (export VARLOCK_TELEMETRY_DISABLED=1 or remove this field)"
-  fi
-  if [ -f "$BAUDBOT_HOME/.config/varlock/config.json" ] && grep -q '"anonymousId"' "$BAUDBOT_HOME/.config/varlock/config.json"; then
-    warn "$BAUDBOT_HOME/.config/varlock/config.json includes anonymousId (export VARLOCK_TELEMETRY_DISABLED=1 or remove this field)"
-  fi
+  # Warn only if a telemetry config exists that is NOT explicitly disabled.
+  # `varlock telemetry disable` leaves an anonymousId behind but sets
+  # "telemetryDisabled": true, so keying off anonymousId would false-positive.
+  for vl_cfg in "$BAUDBOT_HOME/.varlock/config.json" "$BAUDBOT_HOME/.config/varlock/config.json"; do
+    if [ -f "$vl_cfg" ] && ! bb_varlock_telemetry_disabled "$vl_cfg"; then
+      warn "$vl_cfg has telemetry enabled (run 'varlock telemetry disable' or export VARLOCK_TELEMETRY_DISABLED=1)"
+    fi
+  done
 else
   fail "varlock not found"
 fi

--- a/bin/lib/varlock-common.sh
+++ b/bin/lib/varlock-common.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Shared varlock install/version helpers for Baudbot shell scripts.
+#
+# varlock is installed as a standalone SEA binary (not an npm dependency)
+# because it runs at the shell/process-supervision layer for the agent user,
+# outside any Node project. To keep installs reproducible we pin a version and
+# reconcile to it on both first-time setup and `baudbot update`.
+
+# Pinned varlock version. Env-overridable, mirroring the PI_VERSION convention.
+bb_varlock_pinned_version() {
+  echo "${BAUDBOT_VARLOCK_VERSION:-1.7.1}"
+}
+
+# Print the version reported by a varlock binary, whitespace-stripped.
+# Args: $1 = path to varlock binary. Returns non-zero if not runnable.
+bb_varlock_installed_version() {
+  local bin="$1"
+  [ -n "$bin" ] && [ -x "$bin" ] || return 1
+  "$bin" --version 2>/dev/null | head -n1 | tr -d '[:space:]'
+}
+
+# Decide whether a (re)install is needed.
+# Args: $1 = installed version (may be empty), $2 = pinned version.
+# Returns 0 (needs install) when missing or mismatched, 1 when up to date.
+bb_varlock_needs_install() {
+  local installed="$1" pinned="$2"
+  [ -n "$installed" ] && [ "$installed" = "$pinned" ] && return 1
+  return 0
+}
+
+# Return 0 if a varlock config.json has telemetry explicitly disabled.
+# `varlock telemetry disable` leaves an anonymousId in the file but adds
+# "telemetryDisabled": true — so we key off that flag, not anonymousId presence.
+# Args: $1 = path to config.json.
+bb_varlock_telemetry_disabled() {
+  local cfg="$1"
+  [ -f "$cfg" ] || return 1
+  grep -qE '"telemetryDisabled"[[:space:]]*:[[:space:]]*true' "$cfg"
+}
+
+# Install or upgrade varlock for the agent user to the pinned version, persist
+# the telemetry opt-out, and keep the legacy ~/.varlock/bin symlink. Idempotent:
+# safe to call from setup.sh (first install) and update-release.sh (upgrades).
+# Args: $1 = agent unix user, $2 = agent home directory.
+bb_reconcile_varlock() {
+  local agent_user="$1" agent_home="$2"
+  local pinned legacy_bin config_bin config_dir cur_bin="" installed=""
+
+  # Nothing to do if the agent user doesn't exist yet (e.g. test sandboxes, or
+  # update invoked before setup created the user).
+  if ! id "$agent_user" >/dev/null 2>&1; then
+    echo "agent user '$agent_user' not found; skipping varlock reconcile"
+    return 0
+  fi
+
+  pinned="$(bb_varlock_pinned_version)"
+  legacy_bin="$agent_home/.varlock/bin/varlock"
+  config_dir="$agent_home/.config/varlock/bin"
+  config_bin="$config_dir/varlock"
+
+  if [ -x "$config_bin" ]; then
+    cur_bin="$config_bin"
+  elif [ -x "$legacy_bin" ]; then
+    cur_bin="$legacy_bin"
+  fi
+  if [ -n "$cur_bin" ]; then
+    installed="$(sudo -u "$agent_user" "$cur_bin" --version 2>/dev/null | head -n1 | tr -d '[:space:]')"
+  fi
+
+  if bb_varlock_needs_install "$installed" "$pinned"; then
+    echo "Installing varlock $pinned for $agent_user (current: ${installed:-none})..."
+    # The installer takes the version as a CLI arg (NOT an env var), defaults to
+    # "latest", and prefers Homebrew when present. Pin the version, force the
+    # binary path (so the pin is honored — brew only tracks latest), and fix the
+    # install dir so upgrades always land at the same place. The installer's
+    # trailing `varlock --post-install curl` line prints a harmless "Invalid
+    # subcommand" warning on current versions but still exits 0.
+    sudo -u "$agent_user" bash -c \
+      "curl -sSfL https://varlock.dev/install.sh | sh -s -- --version='$pinned' --dir='$config_dir' --force-no-brew"
+  else
+    echo "varlock $pinned already installed for $agent_user, skipping"
+  fi
+
+  # Persist telemetry opt-out (writes "telemetryDisabled": true). Best-effort:
+  # never fail the install if the telemetry command misbehaves.
+  local vbin="$config_bin"
+  [ -x "$vbin" ] || vbin="$legacy_bin"
+  if [ -x "$vbin" ]; then
+    sudo -u "$agent_user" "$vbin" telemetry disable >/dev/null 2>&1 || true
+  fi
+
+  # Newer installers place the binary under ~/.config/varlock/bin. Keep a
+  # compatibility link at ~/.varlock/bin/varlock for existing runtime scripts,
+  # but never clobber a real (non-symlink) legacy binary.
+  if [ -x "$config_bin" ]; then
+    if [ -x "$legacy_bin" ] && [ ! -L "$legacy_bin" ]; then
+      echo "Keeping existing legacy varlock binary at $legacy_bin"
+    else
+      sudo -u "$agent_user" bash -c "mkdir -p '$agent_home/.varlock/bin' && ln -sfn '$config_bin' '$legacy_bin'"
+    fi
+  fi
+}

--- a/bin/lib/varlock-common.test.sh
+++ b/bin/lib/varlock-common.test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Tests for bin/lib/varlock-common.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=bin/lib/varlock-common.sh
+source "$SCRIPT_DIR/varlock-common.sh"
+
+TOTAL=0
+PASSED=0
+FAILED=0
+
+run_test() {
+  local name="$1"
+  shift
+  local out
+
+  TOTAL=$((TOTAL + 1))
+  printf "  %-50s " "$name"
+
+  out="$(mktemp /tmp/baudbot-varlock-common-test-output.XXXXXX)"
+  if "$@" >"$out" 2>&1; then
+    echo "✓"
+    PASSED=$((PASSED + 1))
+  else
+    echo "✗ FAILED"
+    tail -40 "$out" | sed 's/^/    /'
+    FAILED=$((FAILED + 1))
+  fi
+  rm -f "$out"
+}
+
+test_pinned_version_default() {
+  (
+    set -euo pipefail
+    unset BAUDBOT_VARLOCK_VERSION
+    [ "$(bb_varlock_pinned_version)" = "1.7.1" ]
+  )
+}
+
+test_pinned_version_env_override() {
+  (
+    set -euo pipefail
+    BAUDBOT_VARLOCK_VERSION="9.9.9"
+    [ "$(bb_varlock_pinned_version)" = "9.9.9" ]
+  )
+}
+
+test_needs_install_when_missing() {
+  ( set -euo pipefail; bb_varlock_needs_install "" "1.7.1" )
+}
+
+test_needs_install_when_mismatched() {
+  ( set -euo pipefail; bb_varlock_needs_install "1.0.0" "1.7.1" )
+}
+
+test_no_install_when_matched() {
+  ( set -euo pipefail; ! bb_varlock_needs_install "1.7.1" "1.7.1" )
+}
+
+test_telemetry_disabled_true() {
+  (
+    set -euo pipefail
+    local tmp; tmp="$(mktemp -d /tmp/baudbot-varlock.XXXXXX)"
+    trap 'rm -rf "$tmp"' EXIT
+    printf '{\n  "anonymousId": "abc",\n  "telemetryDisabled": true\n}\n' > "$tmp/config.json"
+    bb_varlock_telemetry_disabled "$tmp/config.json"
+  )
+}
+
+test_telemetry_not_disabled_when_only_anonymous_id() {
+  (
+    set -euo pipefail
+    local tmp; tmp="$(mktemp -d /tmp/baudbot-varlock.XXXXXX)"
+    trap 'rm -rf "$tmp"' EXIT
+    # The pre-fix false-positive case: anonymousId present, no disable flag.
+    printf '{\n  "anonymousId": "abc"\n}\n' > "$tmp/config.json"
+    ! bb_varlock_telemetry_disabled "$tmp/config.json"
+  )
+}
+
+test_telemetry_not_disabled_when_missing_file() {
+  ( set -euo pipefail; ! bb_varlock_telemetry_disabled "/nonexistent/config.json" )
+}
+
+echo "=== varlock-common tests ==="
+echo ""
+
+run_test "pinned version default (1.7.1)"          test_pinned_version_default
+run_test "pinned version env override"             test_pinned_version_env_override
+run_test "needs install when missing"              test_needs_install_when_missing
+run_test "needs install when version mismatched"   test_needs_install_when_mismatched
+run_test "no install when version matched"         test_no_install_when_matched
+run_test "telemetry disabled flag detected"        test_telemetry_disabled_true
+run_test "anonymousId alone is not 'disabled'"     test_telemetry_not_disabled_when_only_anonymous_id
+run_test "missing config is not 'disabled'"        test_telemetry_not_disabled_when_missing_file
+
+echo ""
+echo "=== $PASSED/$TOTAL passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -107,6 +107,7 @@ run_shell_tests() {
   run "update release flow" bash bin/update-release.test.sh
   run "rollback release"    bash bin/rollback-release.test.sh
   run "version common"      bash bin/lib/version-common.test.sh
+  run "varlock common"      bash bin/lib/varlock-common.test.sh
   echo ""
 }
 

--- a/bin/update-release.sh
+++ b/bin/update-release.sh
@@ -56,6 +56,8 @@ source "$SCRIPT_DIR/lib/release-runtime-common.sh"
 source "$SCRIPT_DIR/lib/json-common.sh"
 # shellcheck source=bin/lib/version-common.sh
 source "$SCRIPT_DIR/lib/version-common.sh"
+# shellcheck source=bin/lib/varlock-common.sh
+source "$SCRIPT_DIR/lib/varlock-common.sh"
 
 # ---------------------------------------------------------------------------
 # Resolve the full path to npm.  This script runs as root (sudo) where the
@@ -424,6 +426,14 @@ log "target: $TARGET_SHORT"
 run_preflight "$CHECKOUT_DIR"
 publish_release "$CHECKOUT_DIR" "$REPO_URL" "$TARGET_BRANCH"
 run_deploy
+
+# Reconcile the agent's varlock binary to the pinned version before restart so
+# the agent comes back up on the expected version. Non-fatal: a varlock hiccup
+# must not abort an otherwise-good release.
+AGENT_USER="${BAUDBOT_AGENT_USER:-baudbot_agent}"
+log "reconciling varlock ($(bb_varlock_pinned_version)) for $AGENT_USER"
+bb_reconcile_varlock "$AGENT_USER" "/home/$AGENT_USER" || log "warning: varlock reconcile failed"
+
 run_restart_and_health
 
 CURRENT_TARGET=""

--- a/setup.sh
+++ b/setup.sh
@@ -65,6 +65,8 @@ REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$REPO_DIR/bin/lib/runtime-node.sh"
 NODE_VERSION="$(bb_runtime_node_version)"
 PI_VERSION="${BAUDBOT_PI_VERSION:-0.52.12}"
+# shellcheck source=bin/lib/varlock-common.sh
+source "$REPO_DIR/bin/lib/varlock-common.sh"
 NODE_VERSIONED_DIR="$BAUDBOT_HOME/opt/node-v$NODE_VERSION-linux-x64"
 NODE_BIN_DIR="$(bb_runtime_node_bin_dir "$BAUDBOT_HOME")"
 
@@ -248,27 +250,11 @@ done < <(find "$REPO_DIR/pi/extensions" -name package.json -not -path '*/node_mo
 echo "=== Installing Gateway bridge dependencies ==="
 (cd "$REPO_DIR/gateway-bridge" && npm install)
 
-echo "=== Installing varlock ==="
-# varlock must be available to the agent user (start.sh adds ~/.varlock/bin to PATH).
-# Install as agent user so it lands in the right home directory.
-AGENT_VARLOCK="$BAUDBOT_HOME/.varlock/bin/varlock"
-AGENT_VARLOCK_CONFIG_BIN="$BAUDBOT_HOME/.config/varlock/bin/varlock"
-if [ -x "$AGENT_VARLOCK" ] || [ -x "$AGENT_VARLOCK_CONFIG_BIN" ]; then
-  echo "varlock already installed for baudbot_agent, skipping"
-else
-  sudo -u baudbot_agent bash -c 'curl -sSfL https://varlock.dev/install.sh | sh -s'
-fi
-
-# Newer varlock installers place the binary under ~/.config/varlock/bin.
-# Keep a compatibility link at ~/.varlock/bin/varlock for existing runtime scripts.
-# If a real legacy binary already exists, preserve it (do not replace with symlink).
-if [ -x "$AGENT_VARLOCK_CONFIG_BIN" ]; then
-  if [ -x "$AGENT_VARLOCK" ] && [ ! -L "$AGENT_VARLOCK" ]; then
-    echo "Keeping existing legacy varlock binary at $AGENT_VARLOCK"
-  else
-    sudo -u baudbot_agent bash -c "mkdir -p '$BAUDBOT_HOME/.varlock/bin' && ln -sfn '$AGENT_VARLOCK_CONFIG_BIN' '$AGENT_VARLOCK'"
-  fi
-fi
+echo "=== Installing varlock $(bb_varlock_pinned_version) ==="
+# varlock must be available to the agent user (start.sh adds ~/.varlock/bin to
+# PATH). Reconcile to the pinned version, persist the telemetry opt-out, and
+# maintain the legacy symlink — see bin/lib/varlock-common.sh.
+bb_reconcile_varlock baudbot_agent "$BAUDBOT_HOME"
 
 echo "=== Publishing initial git-free /opt release ==="
 # Build an immutable release snapshot from the local source checkout, then deploy

--- a/start.sh
+++ b/start.sh
@@ -21,7 +21,8 @@ NODE_BIN_DIR="$(bb_resolve_runtime_node_bin_dir "$HOME")"
 # Set PATH (varlock may be installed in ~/.varlock/bin or ~/.config/varlock/bin)
 export PATH="$HOME/.varlock/bin:$HOME/.config/varlock/bin:$NODE_BIN_DIR:$PATH"
 
-# Work around varlock telemetry config crash by opting out at runtime.
+# Opt out of varlock telemetry at runtime (belt-and-suspenders: setup also
+# persists this via `varlock telemetry disable`). Inherited by child processes.
 export VARLOCK_TELEMETRY_DISABLED=1
 
 # Validate and load secrets via varlock

--- a/test/shell-scripts.test.mjs
+++ b/test/shell-scripts.test.mjs
@@ -59,6 +59,10 @@ describe("shell script test suites", () => {
     expect(() => runScript("bin/lib/doctor-common.test.sh")).not.toThrow();
   });
 
+  it("varlock helpers", () => {
+    expect(() => runScript("bin/lib/varlock-common.test.sh")).not.toThrow();
+  });
+
   it("baudbot cli", () => {
     expect(() => runScript("bin/baudbot.test.sh")).not.toThrow();
   });


### PR DESCRIPTION
## What

varlock is installed for the agent user as a standalone binary via `curl install.sh`, with **no version pin** and a skip-if-present guard — so deployed agents freeze on whatever version they first received (some as old as 1.0.0; latest is 1.7.1) and `baudbot update` never touched it. This pins the version and reconciles it on both setup and update.

- **`bin/lib/varlock-common.sh`** (new) — shared reconcile helper: pinned version (`BAUDBOT_VARLOCK_VERSION`, default `1.7.1`), install when missing or mismatched, persisted `varlock telemetry disable`, legacy `~/.varlock/bin` symlink. Installs via `sh -s -- --version=<pin> --dir=<config-bin> --force-no-brew` — the installer takes the version as a **CLI arg** (not an env var) and otherwise prefers Homebrew (latest-only), so both flags are required for the pin to actually hold. No-ops cleanly if the agent user doesn't exist yet.
- **`setup.sh`** — replaces the skip-if-present block with one helper call + the pin.
- **`bin/update-release.sh`** — reconciles varlock during `baudbot update` (non-fatal); this is the upgrade path that fixes version drift.
- **`bin/doctor.sh`** — telemetry check now warns when `"telemetryDisabled": true` is **absent**, instead of warning on `anonymousId` presence (which false-positived on a correctly-disabled install, since `varlock telemetry disable` leaves an anonymousId behind).
- **`start.sh`** — corrects the stale "telemetry config crash" comment (kept the runtime opt-out).
- **`bin/ci/setup-{arch,ubuntu}.sh`** — assert the installed version matches the pin (single-sourced from the helper) and add the telemetry opt-out to the smoke test.
- Tests for the helper + `CONFIGURATION.md`.

### Verification

- Reconcile flow verified **end-to-end in an `ubuntu:24.04` container** (real `curl | sh` install as `baudbot_agent`): fresh install → correct version & path, idempotent re-run skips, upgrade to a different pin honors `--version` and stays in the config dir, telemetry flag persisted.
- `npm run lint` (shellcheck, 65 files) and the new `varlock-common.test.sh` (8 cases) pass. update/rollback shell tests unaffected.

> Note: the upstream installer ends with a `varlock --post-install curl` line that prints a harmless `Invalid subcommand: curl` on 1.7.x but exits 0 — cosmetic, not introduced here.

### Out of scope (follow-up)

Rooting the launch chain at `varlock run` (to leverage varlock 1.7's marker-driven nested resolution and drop the `unset SLACK_BROKER_*/GATEWAY_BROKER_*` workaround in `startup-pi.sh`) is deferred — it touches the core launch path and warrants real-VPS verification.

## Checklist

- [x] Tests pass (`npm test` — shell suite + new helper tests; JS lint needs `biome` which isn't installed locally)
- [x] Lint passes (`npm run lint:shell`)
- [x] Docs updated (`CONFIGURATION.md`)
- [x] Security audit — n/a (no security-critical files touched)